### PR TITLE
Select children fixes

### DIFF
--- a/qCC/ccSelectChildrenDlg.cpp
+++ b/qCC/ccSelectChildrenDlg.cpp
@@ -21,6 +21,7 @@ static QString s_lastName;
 static bool s_lastNameState = false;
 static CC_CLASS_ENUM s_lastType = CC_TYPES::POINT_CLOUD;
 static bool s_lastTypeState = true;
+static bool s_lastTypeStrictState = true;
 
 ccSelectChildrenDlg::ccSelectChildrenDlg(QWidget* parent/*=0*/)
 	: QDialog(parent)
@@ -31,6 +32,7 @@ ccSelectChildrenDlg::ccSelectChildrenDlg(QWidget* parent/*=0*/)
 	setWindowFlags(Qt::Tool);
 
 	typeCheckBox->setChecked(s_lastTypeState);
+	typeStrictCheckBox->setChecked(s_lastTypeStrictState);
 	nameCheckBox->setChecked(s_lastNameState);
 	nameLineEdit->setText(s_lastName);
 
@@ -51,6 +53,7 @@ void ccSelectChildrenDlg::onAccept()
 	s_lastNameState = nameCheckBox->isChecked();
 	s_lastName = nameLineEdit->text();
 	s_lastTypeState = typeCheckBox->isChecked();
+	s_lastTypeStrictState = typeCheckBox->isChecked();
 	s_lastType = getSelectedType();
 }
 
@@ -69,4 +72,9 @@ QString ccSelectChildrenDlg::getSelectedName()
 		return QString();
 
 	return nameLineEdit->text();
+}
+
+bool ccSelectChildrenDlg::getStrictMatchState()
+{
+	return typeStrictCheckBox->isChecked();
 }

--- a/qCC/ccSelectChildrenDlg.h
+++ b/qCC/ccSelectChildrenDlg.h
@@ -27,7 +27,7 @@
 //qCC_db
 #include <ccObject.h>
 
-//! Minimal dialog to pick one element in a list (combox box)
+//! Minimal dialog to pick one element in a list (combo box)
 class ccSelectChildrenDlg : public QDialog, public Ui::SelectChildrenDialog
 {
 	Q_OBJECT

--- a/qCC/ccSelectChildrenDlg.h
+++ b/qCC/ccSelectChildrenDlg.h
@@ -44,6 +44,8 @@ public:
 	CC_CLASS_ENUM getSelectedType();
 	//! Returns the selected name (if any)
 	QString getSelectedName();
+	//! Returns the state of the strict type checkbox
+	bool getStrictMatchState();
 
 protected slots:
 

--- a/qCC/db_tree/ccDBRoot.cpp
+++ b/qCC/db_tree/ccDBRoot.cpp
@@ -1926,11 +1926,12 @@ void ccDBRoot::showContextMenu(const QPoint& menuPos)
 				menu.addAction(m_sortSiblingsAZ);
 				menu.addAction(m_sortSiblingsZA);
 				menu.addAction(m_sortSiblingsType);
-				menu.addAction(m_selectByTypeAndName);
 			}
 
 			if (selCount == 1 && !leafObject)
 			{
+				menu.addSeparator();
+				menu.addAction(m_selectByTypeAndName);
 				menu.addSeparator();
 				menu.addAction(m_addEmptyGroup);
 			}

--- a/qCC/db_tree/ccDBRoot.cpp
+++ b/qCC/db_tree/ccDBRoot.cpp
@@ -92,7 +92,7 @@ ccDBRoot::ccDBRoot(ccCustomQTreeView* dbTreeWidget, QTreeView* propertiesTreeWid
 	m_sortSiblingsType = new QAction("Sort siblings by type",this);
 	m_sortSiblingsAZ = new QAction("Sort siblings by name (A-Z)",this);
 	m_sortSiblingsZA = new QAction("Sort siblings by name (Z-A)",this);
-	m_selectByTypeAndName = new QAction("Select siblings by type and/or name",this);
+	m_selectByTypeAndName = new QAction("Select children by type and/or name",this);
 	m_deleteSelectedEntities = new QAction("Delete",this);
 	m_toggleSelectedEntities = new QAction("Toggle",this);
 	m_toggleSelectedEntitiesVisibility = new QAction("Toggle visibility",this);

--- a/qCC/db_tree/ccDBRoot.cpp
+++ b/qCC/db_tree/ccDBRoot.cpp
@@ -1622,19 +1622,22 @@ void ccDBRoot::selectByTypeAndName()
 	CC_CLASS_ENUM type = scDlg.getSelectedType();
 	QString name = scDlg.getSelectedName();
 
-	//some types are exclusive, but some are generic!
-	bool exclusive = true;
+	//some types are exclusive, some are generic, and some can be both
+	//(e.g. Meshes)
+	//
+	//For generic-only types the match type gets overridden and forced to
+	//false because exclusive match makes no sense!
+	bool exclusive;
 	switch (type)
 	{
 	case CC_TYPES::HIERARCHY_OBJECT: //returned if no type is selected (i.e. all objects are selected!)
-	case CC_TYPES::MESH:
 	case CC_TYPES::PRIMITIVE:
 	case CC_TYPES::SENSOR:
 	case CC_TYPES::IMAGE:
 		exclusive = false;
 		break;
 	default:
-		exclusive = true;
+		exclusive = scDlg.getStrictMatchState();
 		break;
 	}
 

--- a/qCC/ui_templates/selectChildrenDlg.ui
+++ b/qCC/ui_templates/selectChildrenDlg.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>500</width>
-    <height>140</height>
+    <height>175</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -20,7 +20,10 @@
       <string>Select children...</string>
      </property>
      <layout class="QFormLayout" name="formLayout">
-      <item row="0" column="0">
+      <property name="fieldGrowthPolicy">
+       <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+      </property>
+      <item row="1" column="0">
        <widget class="QCheckBox" name="typeCheckBox">
         <property name="text">
          <string>of type</string>
@@ -30,17 +33,14 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="1">
-       <widget class="QComboBox" name="typeComboBox"/>
-      </item>
-      <item row="1" column="0">
+      <item row="2" column="0">
        <widget class="QCheckBox" name="nameCheckBox">
         <property name="text">
          <string>with name</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
+      <item row="2" column="1">
        <widget class="QFrame" name="nameFrame">
         <property name="enabled">
          <bool>false</bool>
@@ -62,6 +62,44 @@
           <widget class="QLabel" name="label_2">
            <property name="text">
             <string>(case sensitive)</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QFrame" name="typeFrame">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::StyledPanel</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Raised</enum>
+        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout_6">
+         <property name="margin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QComboBox" name="typeComboBox">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="typeStrictCheckBox">
+           <property name="text">
+            <string>strict</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
            </property>
           </widget>
          </item>
@@ -105,12 +143,12 @@
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>248</x>
-     <y>254</y>
+     <x>257</x>
+     <y>165</y>
     </hint>
     <hint type="destinationlabel">
      <x>157</x>
-     <y>274</y>
+     <y>174</y>
     </hint>
    </hints>
   </connection>
@@ -121,19 +159,19 @@
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>316</x>
-     <y>260</y>
+     <x>325</x>
+     <y>165</y>
     </hint>
     <hint type="destinationlabel">
      <x>286</x>
-     <y>274</y>
+     <y>174</y>
     </hint>
    </hints>
   </connection>
   <connection>
    <sender>typeCheckBox</sender>
    <signal>toggled(bool)</signal>
-   <receiver>typeComboBox</receiver>
+   <receiver>typeFrame</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
@@ -153,12 +191,28 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>54</x>
-     <y>66</y>
+     <x>80</x>
+     <y>102</y>
     </hint>
     <hint type="destinationlabel">
-     <x>288</x>
-     <y>68</y>
+     <x>417</x>
+     <y>111</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>typeStrictCheckBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>typeStrictCheckBox</receiver>
+   <slot>setOn(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>321</x>
+     <y>50</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>321</x>
+     <y>50</y>
     </hint>
    </hints>
   </connection>


### PR DESCRIPTION
Hi, here are some changes to fix the label and behavior of the "select children" functionality.

I added a new checkbox to explicitly choose strict type match, because for some types you may want to do either strict or non-strict match (e.g. Meshes).

Let me know if the changes are OK.

Thanks,
   Antonio