### PR TITLE
#include <malloc.h> changed into #include <stdlib.h> in qRansac plugin.

### DIFF
--- a/plugins/qRANSAC_SD/RANSAC_SD_orig/GfxTL/FlatCopyVector.h
+++ b/plugins/qRANSAC_SD/RANSAC_SD_orig/GfxTL/FlatCopyVector.h
@@ -1,6 +1,6 @@
 #ifndef GfxTL__FLATCOPYVECTOR_HEADER__
 #define GfxTL__FLATCOPYVECTOR_HEADER__
-#include <malloc.h>
+#include <stdlib.h>
 #include <memory.h>
 #include <iterator>
 

--- a/plugins/qRANSAC_SD/RANSAC_SD_orig/GfxTL/KdTree.h
+++ b/plugins/qRANSAC_SD/RANSAC_SD_orig/GfxTL/KdTree.h
@@ -14,7 +14,7 @@
 #include <algorithm>
 #include <memory>
 #include <deque>
-#include <malloc.h>
+#include <stdlib.h>
 
 namespace GfxTL
 {

--- a/plugins/qRANSAC_SD/RANSAC_SD_orig/MiscLib/AlignedAllocator.h
+++ b/plugins/qRANSAC_SD/RANSAC_SD_orig/MiscLib/AlignedAllocator.h
@@ -1,7 +1,7 @@
 #ifndef MiscLib__ALIGNEDALLOCATOR_HEADER__
 #define MiscLib__ALIGNEDALLOCATOR_HEADER__
 #include <memory>
-#include <malloc.h>
+#include <stdlib.h>
 #include <xmmintrin.h>
 #include <limits>
 #ifdef max


### PR DESCRIPTION
The qRANSAC plugin can now compile on Mac OS.
Tested on Mac OS 10.10.2