### PR TITLE
qRANSAC: change from #include <malloc.h> to #include <stdlib.h> (Mac)

### DIFF
--- a/plugins/qRANSAC_SD/RANSAC_SD_orig/GfxTL/FlatCopyVector.h
+++ b/plugins/qRANSAC_SD/RANSAC_SD_orig/GfxTL/FlatCopyVector.h
@@ -1,6 +1,10 @@
 #ifndef GfxTL__FLATCOPYVECTOR_HEADER__
 #define GfxTL__FLATCOPYVECTOR_HEADER__
+#ifndef __APPLE__
 #include <malloc.h>
+#else
+#include <stdlib.h>
+#endif
 #include <memory.h>
 #include <iterator>
 

--- a/plugins/qRANSAC_SD/RANSAC_SD_orig/GfxTL/KdTree.h
+++ b/plugins/qRANSAC_SD/RANSAC_SD_orig/GfxTL/KdTree.h
@@ -14,7 +14,11 @@
 #include <algorithm>
 #include <memory>
 #include <deque>
+#ifndef __APPLE__
 #include <malloc.h>
+#else
+#include <stdlib.h>
+#endif
 
 namespace GfxTL
 {

--- a/plugins/qRANSAC_SD/RANSAC_SD_orig/MiscLib/AlignedAllocator.h
+++ b/plugins/qRANSAC_SD/RANSAC_SD_orig/MiscLib/AlignedAllocator.h
@@ -1,7 +1,11 @@
 #ifndef MiscLib__ALIGNEDALLOCATOR_HEADER__
 #define MiscLib__ALIGNEDALLOCATOR_HEADER__
 #include <memory>
+#ifndef __APPLE__
 #include <malloc.h>
+#else
+#include <stdlib.h>
+#endif
 #include <xmmintrin.h>
 #include <limits>
 #ifdef max


### PR DESCRIPTION
Conditional include directive in order to make the qRANSAC plugin work on Mac OS.
Compiles and works fine on MacOS 10.10.2 and up-to-date ArchLinux.