### PR TITLE
Three small fixes

### DIFF
--- a/CC/src/FastMarchingForPropagation.cpp
+++ b/CC/src/FastMarchingForPropagation.cpp
@@ -221,7 +221,7 @@ float FastMarchingForPropagation::computeTCoefApprox(Cell* currentCell, Cell* ne
 {
 	PropagationCell* cCell = static_cast<PropagationCell*>(currentCell);
 	PropagationCell* nCell = static_cast<PropagationCell*>(neighbourCell);
-	return exp(m_jumpCoef * (cCell->f-nCell->f)) -1.0f;
+	return expm1(m_jumpCoef * (cCell->f-nCell->f));
 }
 
 void FastMarchingForPropagation::findPeaks()

--- a/libs/qCC_db/ccCameraSensor.cpp
+++ b/libs/qCC_db/ccCameraSensor.cpp
@@ -15,6 +15,8 @@
 //#                                                                        #
 //##########################################################################
 
+#include <cmath>
+
 #include "ccCameraSensor.h"
 
 //local
@@ -849,9 +851,9 @@ bool ccCameraSensor::computeUncertainty(const CCVector2& pixel, const float dept
 			const float& f_pix = m_intrinsicParams.focal_pix;
 
 			// computes uncertainty
-			sigma.x = static_cast<ScalarType>(abs(factor * (pixel.x - width/2.0f) / f_pix));
-			sigma.y = static_cast<ScalarType>(abs(factor * (pixel.y - height/2.0f) / f_pix));
-			sigma.z = static_cast<ScalarType>(abs(factor * mu));
+			sigma.x = static_cast<ScalarType>(std::abs(factor * (pixel.x - width/2.0f) / f_pix));
+			sigma.y = static_cast<ScalarType>(std::abs(factor * (pixel.y - height/2.0f) / f_pix));
+			sigma.z = static_cast<ScalarType>(std::abs(factor * mu));
 
 			return true;
 		}
@@ -902,7 +904,7 @@ bool ccCameraSensor::computeUncertainty(CCLib::ReferenceCloud* points, std::vect
 		if (	fromGlobalCoordToLocalCoord(*coordGlobal,coordLocal)
 			&&	fromLocalCoordToImageCoord(coordLocal, coordImage) )
 		{
-			computeUncertainty(coordImage, abs(coordLocal.z), accuracy[i]);
+			computeUncertainty(coordImage, std::abs(coordLocal.z), accuracy[i]);
 		}
 		else
 		{
@@ -1049,7 +1051,7 @@ bool ccCameraSensor::isGlobalCoordInFrustrum(const CCVector3& globalCoord/*, boo
 	const float& n = m_intrinsicParams.zNear_mm;
 	const float& f = m_intrinsicParams.zFar_mm;
 
-	return (-z <= f && -z > n && abs(f+z) >= FLT_EPSILON && abs(n+z) >= FLT_EPSILON);
+	return (-z <= f && -z > n && std::abs(f+z) >= FLT_EPSILON && std::abs(n+z) >= FLT_EPSILON);
 }
 
 CCVector3 ccCameraSensor::computeUpperLeftPoint() const
@@ -1079,8 +1081,8 @@ bool ccCameraSensor::computeFrustumCorners()
 	float ar = static_cast<float>(m_intrinsicParams.arrayWidth) / static_cast<float>(m_intrinsicParams.arrayHeight);
 	float halfFov = m_intrinsicParams.vFOV_rad / 2;
 
-	float xIn = abs( tan(halfFov * ar) );
-	float yIn = abs( tan(halfFov     ) );
+	float xIn = std::abs( tan(halfFov * ar) );
+	float yIn = std::abs( tan(halfFov     ) );
 	const float& zNear = m_intrinsicParams.zNear_mm;
 	const float& zFar  = m_intrinsicParams.zFar_mm;
 
@@ -1106,7 +1108,7 @@ bool ccCameraSensor::computeFrustumCorners()
 	const CCVector3* P5 = m_frustrumInfos.frustumCorners->getPoint(5);
 
 	float dz = P0->z-P5->z;
-	float z = (abs(dz) < FLT_EPSILON ? P0->z : (P0->norm2() - P5->norm2()) / (2*dz));
+	float z = (std::abs(dz) < FLT_EPSILON ? P0->z : (P0->norm2() - P5->norm2()) / (2*dz));
 	
 	m_frustrumInfos.center = CCVector3(0, 0, z);
 

--- a/libs/qCC_db/ccPointCloud.cpp
+++ b/libs/qCC_db/ccPointCloud.cpp
@@ -70,7 +70,7 @@ public:
 	}
 	
 	//! Stops the thread
-	void stop(int timeout = ULONG_MAX)
+	void stop(unsigned long timeout = ULONG_MAX)
 	{
 		m_abort = true;
 		wait(timeout);


### PR DESCRIPTION
- prefer **expm1()** to **exp() - 1.0f** - more accurate for small args (see http://en.cppreference.com/w/cpp/numeric/math/expm1 )
- use **std:abs()** instead of just **abs()** to make sure it gets the right one (see https://stackoverflow.com/questions/21392627/abs-vs-stdabs-what-does-the-reference-say )
- QThread::wait() expects an *unsigned long* (which is what the default ULONG_MAX is - causing a compiler warning)