### PR TITLE
Small fixes

### DIFF
--- a/plugins/qAnimation/qAnimationDlg.cpp
+++ b/plugins/qAnimation/qAnimationDlg.cpp
@@ -28,6 +28,7 @@
 #include <QSettings>
 #include <QElapsedTimer>
 #include <QProgressDialog>
+#include <QMessageBox>
 
 //standard includes
 #include <vector>

--- a/plugins/qFacets/disclaimerDialog.h
+++ b/plugins/qFacets/disclaimerDialog.h
@@ -7,7 +7,7 @@
 #include <ccMainAppInterface.h>
 
 //Qt
-#include <QMainwindow>
+#include <QMainWindow>
 
 //! Dialog for displaying the BRGM disclaimer
 class DisclaimerDialog : public QDialog, public Ui::DisclaimerDialog

--- a/qCC/mainwindow.cpp
+++ b/qCC/mainwindow.cpp
@@ -9540,7 +9540,6 @@ void MainWindow::doActionScalarFieldFromColor()
 			{
 				if (fields[i])
 				{
-					fields[i]->computeMinAndMax();
 
 					int sfIdx = cloud->getScalarFieldIndexByName(fields[i]->getName());
 					if (sfIdx >= 0)
@@ -9563,6 +9562,9 @@ void MainWindow::doActionScalarFieldFromColor()
 						if (!fieldsStr.isEmpty())
 							fieldsStr.append(", ");
 						fieldsStr.append(fields[i]->getName());
+
+						fields[i]->computeMinAndMax();
+
 					}
 					else
 					{


### PR DESCRIPTION
a couple of fixes. 

In particular it looks like that if computeMinMax is called on a field before to add it to its point cloud does not work as expected, the min max is not computed and the scalar field is not colored and remains gray...

in mainwindow.cpp I fixed it moving the call, but maybe a scalar field on which the computeMinMax() method has been called should be add-able  to its cloud without requiring to add the field to the cloud before... 

To check this problem just call doActionScalarFieldFromColor() and look at the output. In my case the fields remains gray with min = max =0 in the range of SF display params in the UI.

This is probably a recenly-introduced unintended behavior cause in the past the action was working as expected...

Luca

