### PR TITLE
Fix loading the QFACETS plugin when compiled with gcc

### DIFF
--- a/libs/qCC_db/ccColorScale.cpp
+++ b/libs/qCC_db/ccColorScale.cpp
@@ -23,6 +23,8 @@
 //Local
 #include "ccLog.h"
 
+const unsigned ccColorScale::MAX_STEPS;
+
 ccColorScale::Shared ccColorScale::Create(QString name)
 {
 	return ccColorScale::Shared(new ccColorScale(name));


### PR DESCRIPTION
The QFACETS plugin cannot be loaded when compiled with gcc because of
a missing symbol:

[11:48:20] [Plugin] Cannot load library .../plugins/libQFACETS_PLUGIN_DLL.so:
  (.../plugins/libQFACETS_PLUGIN_DLL.so: undefined symbol: _ZN12ccColorScale9MAX_STEPSE)

The error seems to be about plugins/qFacets/stereogramDlg.cpp using the
symbol ccColorScale::MAX_STEPS as a parameter of a template function
while the symbol is not properly exported.

Apparently gcc is quite strict about static integer members being
_declared_ in the class declaration but then not explicitly _defined_ in
the implementation.

Some references:
http://stackoverflow.com/questions/3025997/defining-static-const-integer-members-in-class-definition
https://gcc.gnu.org/wiki/VerboseDiagnostics#missing_static_const_definition
https://isocpp.org/wiki/faq/ctors#link-errs-static-data-mems

This is the minimal fix to have the plugin loaded successfully, but for
consistency other static member in the class definition may have to be
defined as well, or even made private if they do not need to be exposed.