### PR TITLE
fix debug compile on linux

### DIFF
--- a/CMakeInclude.cmake
+++ b/CMakeInclude.cmake
@@ -180,28 +180,25 @@ endfunction()
 
 # Default preprocessors
 function( set_default_cc_preproc ) # 1 argument: ARGV0 = target
-set( CC_DEFAULT_PREPROCESSORS NOMINMAX _CRT_SECURE_NO_WARNINGS ) #all configurations
-set( CC_DEFAULT_PREPROCESSORS_RELEASE NDEBUG ) #release specific
-set( CC_DEFAULT_PREPROCESSORS_DEBUG _DEBUG ) #debug specific
+    set( CC_DEFAULT_PREPROCESSORS NOMINMAX _CRT_SECURE_NO_WARNINGS ) #all configurations
+    set( CC_DEFAULT_PREPROCESSORS_RELEASE NDEBUG ) #release specific
+    set( CC_DEFAULT_PREPROCESSORS_DEBUG _DEBUG ) #debug specific
 
-if (MSVC)
-	#disable SECURE_SCL (see http://channel9.msdn.com/shows/Going+Deep/STL-Iterator-Debugging-and-Secure-SCL/)
-	list( APPEND CC_DEFAULT_PREPROCESSORS_RELEASE _SECURE_SCL=0 )
+    if(MSVC)
+            #disable SECURE_SCL (see http://channel9.msdn.com/shows/Going+Deep/STL-Iterator-Debugging-and-Secure-SCL/)
+            list( APPEND CC_DEFAULT_PREPROCESSORS_RELEASE _SECURE_SCL=0 )
 
-	#use VLD for mem leak checking
-	OPTION( OPTION_USE_VISUAL_LEAK_DETECTOR "Check to activate compilation (in debug) with Visual Leak Detector" OFF )
-    if( ${OPTION_USE_VISUAL_LEAK_DETECTOR} )
-		list( APPEND CC_DEFAULT_PREPROCESSORS_DEBUG USE_VLD )
+            #use VLD for mem leak checking
+            OPTION( OPTION_USE_VISUAL_LEAK_DETECTOR "Check to activate compilation (in debug) with Visual Leak Detector" OFF )
+        if( ${OPTION_USE_VISUAL_LEAK_DETECTOR} )
+                    list( APPEND CC_DEFAULT_PREPROCESSORS_DEBUG USE_VLD )
+        endif()
     endif()
-endif()
 
-set_property( TARGET ${ARGV0} APPEND PROPERTY COMPILE_DEFINITIONS ${CC_DEFAULT_PREPROCESSORS} )
-if( NOT CMAKE_CONFIGURATION_TYPES )
-	set_property( TARGET ${ARGV0} APPEND PROPERTY COMPILE_DEFINITIONS ${CC_DEFAULT_PREPROCESSORS_RELEASE} )
-else()
+        set_property( TARGET ${ARGV0} APPEND PROPERTY COMPILE_DEFINITIONS ${CC_DEFAULT_PREPROCESSORS} )
 	set_property( TARGET ${ARGV0} APPEND PROPERTY COMPILE_DEFINITIONS_RELEASE ${CC_DEFAULT_PREPROCESSORS_RELEASE} )
 	set_property( TARGET ${ARGV0} APPEND PROPERTY COMPILE_DEFINITIONS_DEBUG ${CC_DEFAULT_PREPROCESSORS_DEBUG} )
-endif()
+
 endfunction()
 
 if( APPLE )


### PR DESCRIPTION
The line

```cmake
if( NOT CMAKE_CONFIGURATION_TYPES )
	set_property( TARGET ${ARGV0} APPEND PROPERTY COMPILE_DEFINITIONS ${CC_DEFAULT_PREPROCESSORS_RELEASE} )
else()
```
was preventing debug-compile on linux, where most of cmake generators are single-config.  
In the specific the same CC_DEFAULT_PREPROCESSORS_RELEASE options were applied to all the targets, independently by the mode (debug or release) the user is configuring for. Thus if the user expect a debug compile in fact the options were forcing a release mode.

I see there are other places in the same file where CMAKE_CONFIGURATION_TYPES var is used to make decision on what to do... But from a rapid inspection these points seem not critical.


BTW The function
```cmake
function( set_default_cc_preproc ) 
```
Is there a reason for setting the default definitions for each target we are compiling, instead of setting the definitions globally? For example altering the variables:

```cmake
CMAKE_CXX_FLAGS 
    the compiler flags for compiling C++ sources. Note you can also specify switches with ADD_DEFINITIONS(). 
CMAKE_CXX_FLAGS_DEBUG 
    compiler flags for compiling a debug build from C++ sources. 
CMAKE_CXX_FLAGS_RELEASE 
    compiler flags for compiling a release build from C++ sources. 
CMAKE_CXX_FLAGS_RELWITHDEBINFO 
    compiler flags for compiling a release build with debug flags from C++ sources. 
```
E.g. if NOMINMAX and _CRT_SECURE_NO_WARNINGS are always needed we can put them in the main CMakeLists.txt file as 
```cmake
add_definitions(-DNOMINMAX -D_CRT_SECURE_NO_WARNINGS)
```

Well.. if its ok I'll try to prepare a branch with these changes to see if it works correctly