### PR TITLE
Fix dip direction calculation

### DIFF
--- a/libs/qCC_db/ccNormalVectors.cpp
+++ b/libs/qCC_db/ccNormalVectors.cpp
@@ -855,8 +855,17 @@ void ccNormalVectors::ConvertNormalToDipAndDipDir(const CCVector3& N, PointCoord
 		return;
 	}
 
+	// The dip direction must be the same for parallel facets, regardless
+	// of whether their normals point upwards or downwards.
+	//
+	// The formula using atan2() with the swapped N.x and N.y already
+	// gives the correct results for facets with the normal pointing
+	// upwards, so just use the sign of N.z to invert the normals if they
+	// point downwards.
+	double Nsign = copysign(1.0, N.z);
+
 	//"Dip direction is measured in 360 degrees, generally clockwise from North"
-	double dipDir_rad = atan2(N.x,N.y); //result in [-pi,+pi]
+	double dipDir_rad = atan2(Nsign * N.x, Nsign * N.y); //result in [-pi,+pi]
 	if (dipDir_rad < 0)
 		dipDir_rad += 2.0*M_PI;
 

--- a/libs/qCC_db/ccNormalVectors.cpp
+++ b/libs/qCC_db/ccNormalVectors.cpp
@@ -869,9 +869,13 @@ void ccNormalVectors::ConvertNormalToDipAndDipDir(const CCVector3& N, PointCoord
 	if (dipDir_rad < 0)
 		dipDir_rad += 2.0*M_PI;
 
-	//Dip
-	double dip_rad = atan(fabs(N.z)/sqrt(r2)); //atan's result in [-pi/2,+pi/2] but |N.z|/r >= 0
-	dip_rad = (M_PI/2) - dip_rad; //DGM: we always measure the dip downward from horizontal
+	// Dip angle
+	//
+	// acos() returns values in [0, pi] but using fabs() all the normals
+	// are considered pointing upwards, so the actual result will be in
+	// [0, pi/2] as required by the definition of dip.
+	// We skip the division by r because the normal is a unit vector.
+	double dip_rad = acos(fabs(N.z));
 
 	dipDir_deg = static_cast<PointCoordinateType>(dipDir_rad * CC_RAD_TO_DEG);
 	dip_deg = static_cast<PointCoordinateType>(dip_rad * CC_RAD_TO_DEG);


### PR DESCRIPTION
Hi,

the first commit fixes the calculation of the dip direction as mentioned in https://github.com/cloudcompare/trunk/issues/241

The second commit simplifies the calculation of the dip angle.

Thanks,
   Antonio