### PR TITLE
Use CGAL for Delaunay Triangulation and Constrained Delaunay Triangulation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,17 +6,18 @@ compiler:
     - gcc # 4.6
 
 install:
-    # We remove Postgis added by Travis since it prevent us from installing libgdal-dev
+    # We remove Postgis added by Travis since it prevents us from installing libgdal-dev
     - sudo mv /etc/apt/sources.list.d/pgdg-source.list* /tmp/
     - sudo apt-get -qq remove postgis
     - sudo apt-get update -qq
     # Install dependencies
-    - sudo apt-get install -qy cmake libqt4-dev libqt4-opengl-dev libgdal-dev
+    - sudo apt-get install -qy cmake libqt4-dev libqt4-opengl-dev libgdal-dev libcgal-dev
 
 before_script:
     - mkdir build
     - cd build
     - cmake -DCMAKE_BUILD_TYPE=Release \
+      -DCOMPILE_CC_CORE_LIB_WITH_CGAL=ON \
       -DINSTALL_QHPR_PLUGIN=ON \
       -DINSTALL_QPCV_PLUGIN=ON \
       -DINSTALL_QPOISSON_RECON_PLUGIN=ON \

--- a/CC/CMakeLists.txt
+++ b/CC/CMakeLists.txt
@@ -6,12 +6,25 @@ include ( ../CMakePolicies.cmake )
 # Options
 option( COMPILE_CC_CORE_LIB_WITH_QT "Check to compile CC_CORE_LIB with Qt (to enable parallel processing)" ON )
 option( COMPILE_CC_CORE_LIB_WITH_TRIANGLE "Check to compile CC_CORE_LIB with Triangle lib. (to enable Delaunay 2.5D triangulation)" ON )
+option( COMPILE_CC_CORE_LIB_WITH_CGAL "Check to compile CC_CORE_LIB with CGAL lib. (to enable Delaunay 2.5D triangulation with a GPL compliant licence)" OFF )
 option( COMPILE_CC_CORE_LIB_SHARED "Check to compile CC_CORE_LIB as a shared library (DLL/so)" ON )
 
 # to compile CCLib only! (CMake implicitly imposes to declare a project before anything...)
 project( CC_DUMMY_PROJECT )
 
-# CC_CORE_LIB only relies on 'triangle' library...
+# CGAL takes precedence over triangle
+if (COMPILE_CC_CORE_LIB_WITH_CGAL)
+	SET(COMPILE_CC_CORE_LIB_WITH_TRIANGLE OFF)
+	FIND_PACKAGE(CGAL QUIET COMPONENTS Core ) # implies findGMP
+	if(CGAL_FOUND)
+		include( ${CGAL_USE_FILE} )
+		include_directories(${CGAL_INCLUDE_DIR})
+	else()
+		Message(STATUS "Could not find CGAL")
+	endif()
+endif()
+
+# else CC_CORE_LIB only relies on 'triangle' library...
 if (COMPILE_CC_CORE_LIB_WITH_TRIANGLE)
 	add_subdirectory (triangle)
 endif()
@@ -20,6 +33,8 @@ endif()
 if (COMPILE_CC_CORE_LIB_WITH_QT)
 	include( ../CMakeExternalLibs.cmake )
 endif()
+
+
 
 project( CC_CORE_LIB )
 
@@ -32,6 +47,7 @@ if( MSVC )
 endif()
 include_directories( ${triangle_SOURCE_DIR} )
 
+
 file( GLOB header_list include/*.h)
 file( GLOB source_list src/*.cpp src/*.h)
 
@@ -41,10 +57,16 @@ else()
 	add_library( ${PROJECT_NAME} STATIC ${header_list} ${source_list} )
 endif()
 
-target_link_libraries( ${PROJECT_NAME} triangle )
 
 if (COMPILE_CC_CORE_LIB_WITH_TRIANGLE)
+	target_link_libraries( ${PROJECT_NAME} triangle )
 	set_property( TARGET ${PROJECT_NAME} APPEND PROPERTY COMPILE_DEFINITIONS USE_TRIANGLE_LIB )
+endif()
+
+
+if (COMPILE_CC_CORE_LIB_WITH_CGAL)
+	target_link_libraries( ${PROJECT_NAME} ${CGAL_LIBRARIES} )
+	set_property( TARGET ${PROJECT_NAME} APPEND PROPERTY COMPILE_DEFINITIONS USE_CGAL_LIB )
 endif()
 
 if ( COMPILE_CC_CORE_LIB_WITH_QT )

--- a/CC/include/Delaunay2dMesh.h
+++ b/CC/include/Delaunay2dMesh.h
@@ -24,6 +24,7 @@
 #include "Neighbourhood.h"
 #include "SimpleTriangle.h"
 
+
 namespace CCLib
 {
 
@@ -48,7 +49,7 @@ public:
 
 	//! Associate this mesh to a point cloud
 	/** This particular mesh structure deals with point indexes instead of points.
-		Therefore, it is possible to change the associated point cloud (it the
+		Therefore, it is possible to change the associated point cloud (if the
 		new cloud has the same size). For example, it can be useful to compute
 		the mesh on 2D points corresponding to 3D points that have been projected
 		on a plane and then to link this structure with the 3D original	points.
@@ -60,7 +61,6 @@ public:
 	//! Build the Delaunay mesh on top a set of 2D points
 	/** \param points2D a set of 2D points
 		\param pointCountToUse number of points to use from the input set (0 = all)
-		\param forceInputPointsAsBorder if true, the input points are considered as ordered polyon vertices and 'outside' triangles will be removed
 		\param outputErrorStr error string as output by Triangle lib. (if any) [optional]
 		\return success
 	**/

--- a/CC/src/Delaunay2dMesh.cpp
+++ b/CC/src/Delaunay2dMesh.cpp
@@ -28,6 +28,14 @@
 #include <triangle.h>
 #endif
 
+#if USE_CGAL_LIB
+//CGAL Lib
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Constrained_Delaunay_triangulation_2.h>
+#include <CGAL/Triangulation_vertex_base_with_info_2.h>
+#include <CGAL/Delaunay_triangulation_2.h>
+#endif
+
 //system
 #include <assert.h>
 #include <string.h>
@@ -54,7 +62,7 @@ Delaunay2dMesh::~Delaunay2dMesh()
 
 bool Delaunay2dMesh::Available()
 {
-#ifdef USE_TRIANGLE_LIB
+#if defined(USE_TRIANGLE_LIB) ||  defined(USE_CGAL_LIB)
 	return true;
 #else
 	return false;
@@ -78,7 +86,7 @@ bool Delaunay2dMesh::buildMesh(	const std::vector<CCVector2>& points2D,
 								const std::vector<int>& segments2D,
 								char* outputErrorStr/*=0*/)
 {
-#ifdef USE_TRIANGLE_LIB
+#if defined(USE_TRIANGLE_LIB)
 	//we use the external library 'Triangle'
 	triangulateio in;
 	memset(&in,0,sizeof(triangulateio));
@@ -151,6 +159,60 @@ bool Delaunay2dMesh::buildMesh(	const std::vector<CCVector2>& points2D,
 	m_globalIteratorEnd = m_triIndexes + 3*m_numberOfTriangles;
 
 	return true;
+
+#elif defined(USE_CGAL_LIB)
+
+	//CGAL boilerplate
+	typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
+	//We define a vertex_base with info. The "info" (size_t) allow us to keep track of the original point index.
+	typedef CGAL::Triangulation_vertex_base_with_info_2<size_t, K> Vb;
+	typedef CGAL::Constrained_triangulation_face_base_2<K> Fb;
+	typedef CGAL::No_intersection_tag  Itag; //This tag could ben changed if we decide to handle intersection
+	typedef CGAL::Triangulation_data_structure_2<Vb, Fb> Tds;
+	typedef CGAL::Constrained_Delaunay_triangulation_2<K, Tds, Itag> CDT;
+	typedef CDT::Point cgalPoint;
+
+	std::vector< std::pair<cgalPoint, size_t > > constraints;
+	size_t constrCount = segments2D.size();
+
+	try
+	{
+		constraints.reserve(constrCount);
+	} catch (const std::bad_alloc&)
+	{
+		if (outputErrorStr)
+			strcpy(outputErrorStr, "Not enough memory");
+		return false;
+	};
+
+	//We create the Constrained Delaunay Triangulation (CDT)
+	CDT cdt;
+
+	//We build the constraints
+	for(size_t i = 0; i < constrCount; ++i) {
+		const CCVector2 * pt = &points2D[segments2D[i]];
+		constraints.push_back(std::make_pair(cgalPoint(pt->x, pt->y), segments2D[i]));
+	}
+	//The CDT  is built according to the constraints
+	cdt.insert(constraints.begin(), constraints.end());
+
+	m_numberOfTriangles = static_cast<unsigned >(cdt.number_of_faces());
+	m_triIndexes = new int[cdt.number_of_faces()*3];
+
+	//The cgal data structure is converted into CC one
+	if (m_numberOfTriangles > 0) {
+		int faceCount = 0;
+		for (CDT::Face_iterator face = cdt.faces_begin(); face != cdt.faces_end(); ++face, faceCount+=3) {
+			m_triIndexes[0+faceCount] = static_cast<int>(face->vertex(0)->info());
+			m_triIndexes[1+faceCount] = static_cast<int>(face->vertex(1)->info());
+			m_triIndexes[2+faceCount] = static_cast<int>(face->vertex(2)->info());
+		};
+	}
+
+	m_globalIterator = m_triIndexes;
+	m_globalIteratorEnd = m_triIndexes + 3*m_numberOfTriangles;
+	return true;
+
 #else
 
 	if (outputErrorStr)
@@ -164,7 +226,8 @@ bool Delaunay2dMesh::buildMesh(	const std::vector<CCVector2>& points2D,
 								size_t pointCountToUse/*=0*/,
 								char* outputErrorStr/*=0*/)
 {
-#ifdef USE_TRIANGLE_LIB
+#if defined(USE_TRIANGLE_LIB)
+
 	size_t pointCount = points2D.size();
 	//we will use at most 'pointCountToUse' points (if not 0)
 	if (pointCountToUse > 0 && pointCountToUse < pointCount)
@@ -221,10 +284,79 @@ bool Delaunay2dMesh::buildMesh(	const std::vector<CCVector2>& points2D,
 	m_globalIteratorEnd = m_triIndexes + 3*m_numberOfTriangles;
 
 	return true;
+
+#elif defined(USE_CGAL_LIB)
+
+	//CGAL boilerplate
+	typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
+	//We define a vertex_base with info. The "info" (size_t) allow us to keep track of the original point index.
+	typedef CGAL::Triangulation_vertex_base_with_info_2<size_t, K> Vb;
+	typedef CGAL::Triangulation_data_structure_2<Vb> Tds;
+	typedef CGAL::Delaunay_triangulation_2<K, Tds> DT;
+	typedef DT::Point cgalPoint;
+
+	std::vector< std::pair<cgalPoint, size_t > > pts;
+	size_t pointCount = points2D.size();
+
+	//we will use at most 'pointCountToUse' points (if not 0)
+	if (pointCountToUse > 0 && pointCountToUse < pointCount)
+	{
+		pointCount = pointCountToUse;
+	}
+
+	if (pointCount < 3)
+	{
+		if (outputErrorStr)
+			strcpy(outputErrorStr, "Not enough points");
+		return false;
+	}
+
+	try
+	{
+		pts.reserve(pointCount);
+	} catch (const std::bad_alloc&)
+	{
+		if (outputErrorStr)
+			strcpy(outputErrorStr, "Not enough memory");
+		return false;
+	};
+
+	m_numberOfTriangles = 0;
+	if (m_triIndexes)
+	{
+		delete[] m_triIndexes;
+		m_triIndexes = 0;
+	}
+
+	for(size_t i = 0; i < pointCount; ++i) {
+		const CCVector2 * pt = &points2D[i];
+		pts.push_back(std::make_pair(cgalPoint(pt->x, pt->y), i));
+	}
+
+	//The delaunay triangulation is built according to the 2D point cloud
+	DT dt(pts.begin(), pts.end());
+
+	m_numberOfTriangles = static_cast<unsigned >(dt.number_of_faces());
+	m_triIndexes = new int[dt.number_of_faces()*3];
+
+	//The cgal data structure is converted into CC one
+	if (m_numberOfTriangles > 0) {
+		int faceCount = 0;
+		for (DT::Face_iterator face = dt.faces_begin(); face != dt.faces_end(); ++face, faceCount+=3) {
+			m_triIndexes[0+faceCount] = static_cast<int>(face->vertex(0)->info());
+			m_triIndexes[1+faceCount] = static_cast<int>(face->vertex(1)->info());
+			m_triIndexes[2+faceCount] = static_cast<int>(face->vertex(2)->info());
+		};
+	}
+
+	m_globalIterator = m_triIndexes;
+	m_globalIteratorEnd = m_triIndexes + 3*m_numberOfTriangles;
+	return true;
+
 #else
 
 	if (outputErrorStr)
-		strcpy(outputErrorStr, "Triangle library not supported");
+		strcpy(outputErrorStr, "Please link CC lib with either Triangle or CGAL");
 	return false;
 
 #endif

--- a/qCC/TODO.txt
+++ b/qCC/TODO.txt
@@ -35,7 +35,6 @@ Big ones:
 [*] Update qKinect with the Kinect for Windows SDK (1.8)
 [*] Use the LEAP device to interact with point clouds (http://www.danielgm.net/cc/forum/viewtopic.php?t=1090)
 [*] Finish the Oculus Rift plugin
-[*] Change Triangle lib by a GPL-compatible library
 [*] Use PDAL instead of libLAS (http://www.cloudcompare.org/forum/viewtopic.php?t=437)
 
 Various:

--- a/qCC/mainwindow.cpp
+++ b/qCC/mainwindow.cpp
@@ -5768,9 +5768,8 @@ void MainWindow::doConvertPolylinesToMesh()
 		ccLog::Error("Not enough segments!");
 		return;
 	}
-
-#define USE_TRIANGLE_LIB
-#ifdef USE_TRIANGLE_LIB
+#define USE_CGAL_LIB
+#if defined(USE_TRIANGLE_LIB) || defined(USE_CGAL_LIB)
 	std::vector<CCVector2> points2D;
 	std::vector<int> segments2D;
 	try


### PR DESCRIPTION
cc @Wookey

As pointed by Debian FTPMaster, the "not so free" license of Triangle library is not compatible with the LGPL/GPL license scheme adopted by CC.
This commit allow to use CGAL, a well established (and packaged) LGPL/GPL library of geometric processing instead of Triangle where needed.
This implementation is *a priori* on parity with Triangle one with regards of the repetability. It's a little bit faster and maybe it have a small memory overhead.
Alternatively Triangle can still be used (and is the default build choice in the CMakeList.txt)  to allow a smooth transition. But it can be safely removed in order to eventually push a DSFG package of CloudCompare.

Travis script is updated to use CGAL instead of Triangle.