### PR TITLE
Enforce usage of C++11 for UNIX compilers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,9 +28,16 @@ if(MSVC)
   set( CMAKE_DEBUG_POSTFIX d )
 endif()
 
+# You need a c++11 Compiler to build CC
 if( UNIX )
-        set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
+    include(CheckCXXCompilerFlag)
+    CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
+    if(COMPILER_SUPPORTS_CXX11)
+        set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fPIC")
         set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
+    else()
+        message(ERROR "Your compiler does not support C++11")
+    endif()
 endif()
 
 if( MSVC )


### PR DESCRIPTION
This commit intends to add a very basic check of c++11 capabilities on Linux/MacOS (i.e. for Clang and GCC)
it takes inspiration on 
https://www.guyrutenberg.com/2014/01/05/enabling-c11-c0x-in-cmake/
and
https://github.com/openMVG/openMVG/blob/master/src/cmakeFindModules/CXX11.cmake
Note that I do not take into account c++0x to be sure that a minimum of c++11 compatibility is assured. 