### PR TITLE
getting rid of the global cmake var EXTERNAL_LIBS_LIBRARIES. It was c…

### DIFF
--- a/CMakeInclude.cmake
+++ b/CMakeInclude.cmake
@@ -9,22 +9,6 @@ else()
 	set( SHARED_LIB_TYPE LIBRARY )
 endif()
 
-if ( NOT USE_QT5 )
-
-# Find mocable files (simply look for Q_OBJECT in all files!)
-function( find_mocable_files __out_var_name )   # + input list
-    set( local_list )
-    foreach( one_file ${ARGN} )
-        file( READ ${one_file} stream )
-        if( stream MATCHES "Q_OBJECT" )
-            list( APPEND local_list ${one_file} )
-        endif()
-    endforeach()
-    set( ${__out_var_name} ${local_list} PARENT_SCOPE )
-endfunction()
-
-endif() #if ( NOT USE_QT5 )
-
 # Export Qt Dlls to specified destinations
 function( install_Qt_Dlls ) # 2 arguments: ARGV0 = release destination / ARGV1 = debug destination
 if( WIN32 )

--- a/ccViewer/CMakeLists.txt
+++ b/ccViewer/CMakeLists.txt
@@ -9,7 +9,7 @@ if( MSVC )
 endif()
 include_directories( ${QCC_IO_LIB_SOURCE_DIR} )
 include_directories( ${QCC_GL_LIB_SOURCE_DIR} )
-include_directories( ${EXTERNAL_LIBS_INCLUDE_DIR} )
+
 include_directories( ${CloudComparePlugins_SOURCE_DIR} )
 include_directories( ${CMAKE_CURRENT_SOURCE_DIR} )
 include_directories( ${CMAKE_CURRENT_SOURCE_DIR}/../qCC )
@@ -39,20 +39,8 @@ if ( ${OPTION_SUPPORT_3DCONNEXION_DEVICES} )
 	list( APPEND source_list ${3DX_source_list} )
 endif()	
 
-if ( NOT USE_QT5 )
-
-# find Qt mocable files
-find_mocable_files( mocable_list ${header_list} )
-qt4_wrap_cpp( moc_list ${mocable_list} )
-qt4_wrap_ui( generated_ui_list ${ui_list} )
-qt4_add_resources( generated_qrc_list ${qrc_list} )
-
-else()
-
-qt5_wrap_ui( generated_ui_list ${ui_list} )
-qt5_add_resources( generated_qrc_list ${qrc_list} )
-
-endif()
+qt_wrap_ui( generated_ui_list ${ui_list} )
+qt_add_resources( generated_qrc_list ${qrc_list} )
 
 # App icon with MSVC
 if( MSVC )
@@ -74,7 +62,6 @@ target_link_libraries( ${PROJECT_NAME} CC_CORE_LIB )
 target_link_libraries( ${PROJECT_NAME} QCC_DB_LIB )
 target_link_libraries( ${PROJECT_NAME} QCC_IO_LIB )
 target_link_libraries( ${PROJECT_NAME} QCC_GL_LIB )
-target_link_libraries( ${PROJECT_NAME} ${EXTERNAL_LIBS_LIBRARIES} )
 
 if ( USE_QT5 )
 	if (WIN32)

--- a/libs/CCFbo/CMakeLists.txt
+++ b/libs/CCFbo/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8)
 
-include_directories( ${EXTERNAL_LIBS_INCLUDE_DIR} )
+
 include_directories( ${CMAKE_CURRENT_SOURCE_DIR}/include )
 include_directories( ${GLEW_LIB_SOURCE_DIR}/include )
 
@@ -9,19 +9,17 @@ project( CC_FBO_LIB )
 file( GLOB header_list include/*.h )
 file( GLOB source_list src/*.cpp )
 
-if ( NOT USE_QT5 )
-	# find Qt mocable files
-	find_mocable_files( mocable_list ${header_list} )
-	qt4_wrap_cpp( moc_list ${mocable_list} )
-endif()
+
 
 add_library( ${PROJECT_NAME} STATIC ${header_list} ${source_list} )
 
 target_link_libraries( ${PROJECT_NAME} GLEW_LIB )
-target_link_libraries( ${PROJECT_NAME} ${EXTERNAL_LIBS_LIBRARIES} )
+
 
 if ( USE_QT5 )
 	qt5_use_modules(${PROJECT_NAME} Core ) # Widgets
+else()
+    target_link_libraries( ${PROJECT_NAME} ${QT_LIBRARIES} )
 endif()
 
 # Default preprocessors

--- a/libs/qCC_db/CMakeLists.txt
+++ b/libs/qCC_db/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 2.8)
 
-include_directories( ${EXTERNAL_LIBS_INCLUDE_DIR} )
 include_directories( ${GLEW_LIB_SOURCE_DIR}/include )
 include_directories( ${CC_CORE_LIB_SOURCE_DIR}/include )
 include_directories( ${CC_FBO_LIB_SOURCE_DIR}/include )
@@ -13,21 +12,16 @@ project( QCC_DB_LIB )
 file( GLOB header_list *.h)
 file( GLOB source_list *.cpp)
 
-if ( NOT USE_QT5 )
-	# find Qt mocable files
-	find_mocable_files( mocable_list ${header_list} )
-	qt4_wrap_cpp( moc_list ${mocable_list} )
-endif()
-
 add_library( ${PROJECT_NAME} SHARED ${header_list} ${source_list} ${moc_list} )
 
 target_link_libraries( ${PROJECT_NAME} CC_CORE_LIB )
 target_link_libraries( ${PROJECT_NAME} GLEW_LIB )
 target_link_libraries( ${PROJECT_NAME} CC_FBO_LIB )
-target_link_libraries( ${PROJECT_NAME} ${EXTERNAL_LIBS_LIBRARIES} )
 
 if ( USE_QT5 )
 	qt5_use_modules(${PROJECT_NAME} Core Gui Widgets OpenGL)
+else()
+    target_link_libraries( ${PROJECT_NAME} ${QT_LIBRARIES})
 endif()
 
 

--- a/libs/qCC_glWindow/CMakeLists.txt
+++ b/libs/qCC_glWindow/CMakeLists.txt
@@ -24,6 +24,7 @@ target_link_libraries( ${PROJECT_NAME} CC_FBO_LIB )
 
 if ( USE_QT5 )
 	qt5_use_modules(${PROJECT_NAME} Core Gui Widgets OpenGL)
+        target_link_libraries( ${PROJECT_NAME} ${OPENGL_LIBRARIES})
 else()
     target_link_libraries( ${PROJECT_NAME} ${QT_LIBRARIES} ${OPENGL_LIBRARIES})
 endif()

--- a/libs/qCC_glWindow/CMakeLists.txt
+++ b/libs/qCC_glWindow/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8)
 
 include_directories( ${CMAKE_CURRENT_SOURCE_DIR} )
-include_directories( ${EXTERNAL_LIBS_INCLUDE_DIR} )
+
 include_directories( ${GLEW_LIB_SOURCE_DIR}/include )
 include_directories( ${CC_CORE_LIB_SOURCE_DIR}/include )
 include_directories( ${CC_FBO_LIB_SOURCE_DIR}/include )
@@ -15,22 +15,17 @@ project( QCC_GL_LIB )
 file( GLOB header_list *.h)
 file( GLOB source_list *.cpp)
 
-if ( NOT USE_QT5 )
-	# find Qt mocable files
-	find_mocable_files( mocable_list ${header_list} )
-	qt4_wrap_cpp( moc_list ${mocable_list} )
-endif()
-
 add_library( ${PROJECT_NAME} STATIC ${header_list} ${source_list} ${moc_list} )
 
 target_link_libraries( ${PROJECT_NAME} CC_CORE_LIB )
 target_link_libraries( ${PROJECT_NAME} QCC_DB_LIB )
 target_link_libraries( ${PROJECT_NAME} GLEW_LIB )
 target_link_libraries( ${PROJECT_NAME} CC_FBO_LIB )
-target_link_libraries( ${PROJECT_NAME} ${EXTERNAL_LIBS_LIBRARIES} )
 
 if ( USE_QT5 )
 	qt5_use_modules(${PROJECT_NAME} Core Gui Widgets OpenGL)
+else()
+    target_link_libraries( ${PROJECT_NAME} ${QT_LIBRARIES} ${OPENGL_LIBRARIES})
 endif()
 
 # Default preprocessors

--- a/libs/qCC_io/CMakeLists.txt
+++ b/libs/qCC_io/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 2.8)
 
 include_directories( ${CMAKE_CURRENT_SOURCE_DIR} )
-include_directories( ${EXTERNAL_LIBS_INCLUDE_DIR} )
 include_directories( ${GLEW_LIB_SOURCE_DIR}/include )
 include_directories( ${CC_CORE_LIB_SOURCE_DIR}/include )
 include_directories( ${CC_FBO_LIB_SOURCE_DIR}/include )
@@ -25,24 +24,18 @@ if( ${OPTION_SUPPORT_MAC_PDMS_FORMAT} )
 	list( APPEND source_list ${PDMS_source_list} )
 endif()
 
-if ( USE_QT5 )
-	qt5_wrap_ui( generated_ui_list ${ui_list} )
-else()
-	# find Qt mocable files
-	find_mocable_files( mocable_list ${header_list} )
-	qt4_wrap_cpp( moc_list ${mocable_list} )
-	qt4_wrap_ui( generated_ui_list ${ui_list} )
-endif()	
-
+qt_wrap_ui( generated_ui_list ${ui_list} )
 add_library( ${PROJECT_NAME} SHARED ${header_list} ${source_list} ${moc_list} ${generated_ui_list} )
 
 target_link_libraries( ${PROJECT_NAME} CC_CORE_LIB )
 target_link_libraries( ${PROJECT_NAME} CC_FBO_LIB )
 target_link_libraries( ${PROJECT_NAME} QCC_DB_LIB )
-target_link_libraries( ${PROJECT_NAME} ${EXTERNAL_LIBS_LIBRARIES} )
+
 
 if ( USE_QT5 )
 	qt5_use_modules(${PROJECT_NAME} Core)	
+else()
+    target_link_libraries( ${PROJECT_NAME} ${QT_LIBRARIES} )
 endif()
 
 # contrib. libraries support

--- a/plugins/CMakePluginTpl.cmake
+++ b/plugins/CMakePluginTpl.cmake
@@ -34,16 +34,9 @@ if (CC_PLUGIN_CUSTOM_UI_LIST)
 	list( APPEND ui_list ${CC_PLUGIN_CUSTOM_UI_LIST} )
 endif()
 
-if ( USE_QT5 )
-	qt5_wrap_ui( generated_ui_list ${ui_list} )
-	qt5_add_resources( generated_qrc_list ${qrc_list} )
-else()
-	# find Qt mocable files (do this AFTER including custom header and source files ;) 
-	find_mocable_files( mocable_list ${header_list} )
-	qt4_wrap_cpp( moc_list ${mocable_list} )
-	qt4_wrap_ui( generated_ui_list ${ui_list} )
-	qt4_add_resources( generated_qrc_list ${qrc_list} )
-endif()
+
+qt_wrap_ui( generated_ui_list ${ui_list} )
+qt_add_resources( generated_qrc_list ${qrc_list} )
 
 add_library( ${PROJECT_NAME} SHARED ${header_list} ${source_list} ${moc_list} ${generated_ui_list} ${generated_qrc_list})
 
@@ -69,7 +62,6 @@ target_link_libraries( ${PROJECT_NAME} CC_CORE_LIB )
 target_link_libraries( ${PROJECT_NAME} QCC_DB_LIB )
 target_link_libraries( ${PROJECT_NAME} QCC_IO_LIB )
 target_link_libraries( ${PROJECT_NAME} QCC_GL_LIB )
-target_link_libraries( ${PROJECT_NAME} ${EXTERNAL_LIBS_LIBRARIES} )
 
 if ( USE_QT5 )
 	qt5_use_modules(${PROJECT_NAME} Core Gui Widgets OpenGL Concurrent)

--- a/plugins/qPCL/PclUtils/CMakeLists.txt
+++ b/plugins/qPCL/PclUtils/CMakeLists.txt
@@ -25,17 +25,9 @@ file( GLOB_RECURSE header_list *.h )
 file( GLOB_RECURSE source_list *.cpp )
 file( GLOB_RECURSE impl_list *.hpp)
 file( GLOB_RECURSE ui_list *.ui )
-#file( GLOB qrc_list icons/*.qrc )
-#file( GLOB rc_list *.rc )
 
-if ( USE_QT5 )
-	qt5_wrap_ui( generated_ui_list ${ui_list} )
-else()
-	# find Qt mocable files
-	find_mocable_files( mocable_list ${header_list} )
-	qt4_wrap_cpp( moc_list ${mocable_list} )
-	qt4_wrap_ui( generated_ui_list ${ui_list} )
-endif()
+
+qt_wrap_ui(generated_ui_list ${ui_list})
 
 add_library( ${PROJECT_NAME} STATIC ${header_list} ${source_list} ${impl_list} ${moc_list} ${generated_ui_list} )
 
@@ -59,7 +51,7 @@ endif()
 
 link_directories( ${PCL_LIBRARY_DIRS} )
 add_definitions( ${PCL_DEFINITIONS} )
-target_link_libraries( ${PROJECT_NAME} ${PCL_LIBRARIES} ${EXTERNAL_LIBS_LIBRARIES})
+target_link_libraries( ${PROJECT_NAME} ${PCL_LIBRARIES})
 
 if ( USE_QT5 )
 	qt5_use_modules(${PROJECT_NAME} Core Gui Widgets)

--- a/plugins/qPCV/PCV/CMakeLists.txt
+++ b/plugins/qPCV/PCV/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8)
 
 include_directories( ${CMAKE_CURRENT_SOURCE_DIR} )
 include_directories( ${CC_CORE_LIB_SOURCE_DIR}/include )
-include_directories( ${EXTERNAL_LIBS_INCLUDE_DIR} )
+
 
 project( PCV_LIB )
 
@@ -12,7 +12,6 @@ file( GLOB source_list *.cpp )
 add_library( ${PROJECT_NAME} STATIC ${header_list} ${source_list} )
 
 target_link_libraries( ${PROJECT_NAME} CC_CORE_LIB )
-target_link_libraries( ${PROJECT_NAME} ${EXTERNAL_LIBS_LIBRARIES} )
 
 # Add prepocessor definitions
 set_property( TARGET ${PROJECT_NAME} APPEND PROPERTY COMPILE_DEFINITIONS NOMINMAX _CRT_SECURE_NO_WARNINGS )

--- a/qCC/CMakeLists.txt
+++ b/qCC/CMakeLists.txt
@@ -15,7 +15,6 @@ if( MSVC )
 endif()
 include_directories( ${QCC_IO_LIB_SOURCE_DIR} )
 include_directories( ${QCC_GL_LIB_SOURCE_DIR} )
-include_directories( ${EXTERNAL_LIBS_INCLUDE_DIR} )
 include_directories( ${CloudComparePlugins_SOURCE_DIR} )
 include_directories( ${CMAKE_CURRENT_SOURCE_DIR} )
 include_directories( ${CMAKE_CURRENT_SOURCE_DIR}/db_tree )
@@ -41,19 +40,11 @@ endif()
 
 file( GLOB ui_list ui_templates/*.ui )
 file( GLOB qrc_list *.qrc )
-#file( GLOB rc_list *.rc )
-file( GLOB txt_list TODO.txt bin_other/history.txt tr/*.qm )
 
-if ( USE_QT5 )
-	qt5_wrap_ui( generated_ui_list ${ui_list} )
-	qt5_add_resources( generated_qrc_list ${qrc_list} )
-else()
-	# find Qt mocable files
-	find_mocable_files( mocable_list ${header_list} )
-	qt4_wrap_cpp( moc_list ${mocable_list} )
-	qt4_wrap_ui( generated_ui_list ${ui_list} )
-	qt4_add_resources( generated_qrc_list ${qrc_list} )
-endif()
+file( GLOB txt_list TODO.txt bin_other/history.txt )
+
+qt_wrap_ui( generated_ui_list ${ui_list} )
+qt_add_resources( generated_qrc_list ${qrc_list} )
 
 # App icon with MSVC
 if( MSVC )
@@ -75,13 +66,17 @@ target_link_libraries( ${PROJECT_NAME} CC_CORE_LIB )
 target_link_libraries( ${PROJECT_NAME} QCC_DB_LIB )
 target_link_libraries( ${PROJECT_NAME} QCC_IO_LIB )
 target_link_libraries( ${PROJECT_NAME} QCC_GL_LIB )
-target_link_libraries( ${PROJECT_NAME} ${EXTERNAL_LIBS_LIBRARIES} )
+
 
 if ( USE_QT5 )
 	if (WIN32)
+        qt5_use_modules(${PROJECT_NAME} Core Gui Widgets OpenGL PrintSupport)
 		target_link_libraries( ${PROJECT_NAME} Qt5::WinMain )
+    else()
+		qt5_use_modules(${PROJECT_NAME} Core Gui Widgets OpenGL PrintSupport)
 	endif()
-	qt5_use_modules(${PROJECT_NAME} Core Gui Widgets OpenGL PrintSupport)
+else()
+    target_link_libraries( ${PROJECT_NAME} ${QT_LIBRARIES})
 endif()
 
 # contrib. libraries support
@@ -132,12 +127,6 @@ endif()
 # Install auxiliary files
 foreach( filename ${auxFiles} )
 	install_ext( FILES ${filename} ${CLOUDCOMPARE_DEST_FOLDER} )
-endforeach()
-
-# Translation files
-file( GLOB tr_list tr/*.qm )
-foreach( filename ${tr_list} )
-	install_ext( FILES ${filename} ${CLOUDCOMPARE_DEST_FOLDER} /tr )
 endforeach()
 
 # in order to ensure that everything else is installed first, put the Mac bundling in its own subdirectory


### PR DESCRIPTION
…ollecting just a couple of libraries (qt plus opengl)

But not all the plugins (or other target) need to be linked against OpenGl and not all plugins need to be linked against all the qt libs. I removed this variable in favour of explicit target linking, in the specific:
 - when using qt4 the target is linked against ${QT_LIBRARIES}
 - when on qt5 the linkage is specified by the qt5_use_modules function.
 - Link to openGl is made only where necessary
Furthermore OpenGL include is made when the package has been found.

there is no need to keep a find_mocable_files function i think (?).
CMake has its own automatic wrapping system that automatically wraps cpp files as needed. It is now enabled: see set(CMAKE_AUTOMOC ON) this should work both with qt4 and qt5