### PR TITLE
ffmpegSupport.cmake message function call fix

### DIFF
--- a/plugins/qAnimation/QTFFmpegWrapper/ffmpegSupport.cmake
+++ b/plugins/qAnimation/QTFFmpegWrapper/ffmpegSupport.cmake
@@ -65,7 +65,7 @@ if (WIN32)
 		file (GLOB SW_DLLS ${FFMPEG_BINARY_DIR}/sw*.dll)
 		LIST( APPEND FFMEG_DLL ${SW_DLLS} )
 
-		message(${FFMEG_DLL})
+		message(STATUS "${FFMEG_DLL}")
 		
 		copy_files("${FFMEG_DLL}" ${ARGV0}) #mind the quotes
 	


### PR DESCRIPTION
I've just found you guys, and I wanted to create a custom build of the app, but I got a problem with a cmake.
With cmake 3.4.1 I got a error message saying that the message function has been called with incorrect number of arguments. So I've fixed it. Maybe it is working with older versions of cmake if you use the message function with one argument, but I haven't tested it.