### PR TITLE
Plugin paths

### DIFF
--- a/plugins/ccPluginInfo.h
+++ b/plugins/ccPluginInfo.h
@@ -11,46 +11,24 @@
 //#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         #
 //#  GNU General Public License for more details.                          #
 //#                                                                        #
-//#          COPYRIGHT: EDF R&D / TELECOM ParisTech (ENST-TSI)             #
+//#          COPYRIGHT: Andy Maloney                                       #
 //#                                                                        #
 //##########################################################################
 
-#ifndef CC_PLUGIN_DIALOG_HEADER
-#define CC_PLUGIN_DIALOG_HEADER
+#ifndef CC_PLUGIN_INFO
+#define CC_PLUGIN_INFO
 
-#include <QDialog>
-#include <QIcon>
+#include <QPair>
+#include <QVector>
 
-#include "ccPluginInfo.h"
+class QObject;
+class QString;
 
-class QLabel;
-class QPushButton;
-class QStringList;
-class QTreeWidget;
-class QTreeWidgetItem;
+//! This type is used to communicate information between the main window and the plugin dialog
+//! It is a pair - first is path to the plugin, second is an object pointer to the plugin
+typedef QPair<QString, QObject*>    tPluginInfo;
 
-//! Dialog to display the loaded plugin list
-class ccPluginDlg : public QDialog
-{
-	Q_OBJECT
+//! Simply a list of \see tPluginInfo
+typedef QVector<tPluginInfo>        tPluginInfoList;
 
-public:
-	ccPluginDlg(const QStringList &paths,
-				const tPluginInfoList &pluginInfoList,
-				QWidget *parent = 0);
-
-protected:
-	void addPluginInfo(const QStringList &paths, const tPluginInfoList &pluginInfoList);
-	void populateTreeWidget(QObject *plugin, const QString &name, const QString &path = QString());
-	void addItems(	QTreeWidgetItem *pluginItem,
-					const char *interfaceName,
-					const QStringList &features);
-
-	QLabel *label;
-	QTreeWidget *treeWidget;
-	QPushButton *okButton;
-	QIcon interfaceIcon;
-	QIcon featureIcon;
-};
-
-#endif
+#endif //CC_PLUGIN_INFO

--- a/qCC/mainwindow.cpp
+++ b/qCC/mainwindow.cpp
@@ -365,11 +365,11 @@ void MainWindow::loadPlugins()
 #if 0
 	// used for development only - this is the path where the plugins are built
 	// this avoids having to copy into the application bundle
-	m_pluginsPaths += (path + "../../../ccPlugins");
+	m_pluginPaths += (path + "../../../ccPlugins");
 #endif
 #else
 	//plugins are in bin/plugins
-	m_pluginsPaths += (QCoreApplication::applicationDirPath()+QString("/plugins"));
+	m_pluginPaths += (QCoreApplication::applicationDirPath()+QString("/plugins"));
 #endif
 
 	// Add any app data paths

--- a/qCC/mainwindow.h
+++ b/qCC/mainwindow.h
@@ -20,13 +20,11 @@
 
 //qCC_plugins
 #include <ccMainAppInterface.h>
+#include <ccPluginInfo.h>
 
 //Qt
 #include <QMainWindow>
-#include <QString>
-#include <QDialog>
 #include <QDir>
-#include <QActionGroup>
 
 //CCLib
 #include <AutoSegmentationTools.h>
@@ -679,8 +677,8 @@ protected:
 	ccPrimitiveFactoryDlg* m_pfDlg;
 
 	/*** plugins ***/
-	QString m_pluginsPath;
-	QStringList m_pluginFileNames;
+	QStringList m_pluginPaths;
+	tPluginInfoList m_pluginInfoList;
 	QList<ccStdPluginInterface*> m_stdPlugins;
 	QList<QToolBar*> m_stdPluginsToolbars;
 	QActionGroup m_glFilterActions;


### PR DESCRIPTION
- adds each of the `QStandardPaths::AppDataLocation` paths (which are platform specific) + "plugins"
- plugins found in those paths will override included plugins if the name of the plugin (from within the plugin - _not_ the file name) matches
- ccPluginDlg no longer reloads the plugins just to get the name
- ccPluginDlg now shows all paths searched and adds a tooltip to each plugin to show the path it came from