### PR TITLE
More fixes

### DIFF
--- a/CC/CMakeLists.txt
+++ b/CC/CMakeLists.txt
@@ -27,7 +27,6 @@ include_directories( ${CMAKE_CURRENT_SOURCE_DIR}/include )
 if( MSVC )
 	include_directories( ${CMAKE_CURRENT_SOURCE_DIR}/include/msvc )
 endif()
-include_directories( ${triangle_SOURCE_DIR} )
 
 
 file( GLOB header_list include/*.h)

--- a/CMakeExternalLibs.cmake
+++ b/CMakeExternalLibs.cmake
@@ -60,7 +60,7 @@ include_directories(${Qt5OpenGL_INCLUDE_DIRS}
 # ------------------------------------------------------------------------------
 # OpenMP
 # ------------------------------------------------------------------------------
-find_package(OpenMP)
+find_package(OpenMP QUIET)
 if (OPENMP_FOUND)
 	message("OpenMP found")
     set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")

--- a/CMakeExternalLibs.cmake
+++ b/CMakeExternalLibs.cmake
@@ -66,15 +66,3 @@ if (OPENMP_FOUND)
     set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
 endif()
-
-# ------------------------------------------------------------------------------
-# Some macros for easily passing from qt4 to qt5 when we will be ready
-# ------------------------------------------------------------------------------
-macro(qt_wrap_ui)
-    qt5_wrap_ui(${ARGN})
-endmacro()
-
-
-macro(qt_add_resources)
-    qt5_add_resources(${ARGN})
-endmacro()

--- a/CMakeExternalLibs.cmake
+++ b/CMakeExternalLibs.cmake
@@ -25,12 +25,6 @@ find_package(Qt5OpenGLExtensions)
 # in the case no Qt5Config.cmake file could be found, cmake will explicitly ask the user for the QT5_DIR containing it!
 # thus no need to keep additional variables and checks
 
-if ( MSVC )
-	# Where to find OpenGL libraries
-	set(WINDOWS_OPENGL_LIBS "C:\\Program Files (x86)\\Windows Kits\\8.0\\Lib\\win8\\um\\x64" CACHE PATH "WindowsSDK libraries" )
-	list( APPEND CMAKE_PREFIX_PATH ${WINDOWS_OPENGL_LIBS} )
-endif()
-
 get_target_property(QT5_LIB_LOCATION Qt5::Core LOCATION_${CMAKE_BUILD_TYPE})
 get_filename_component(QT_BINARY_DIR ${QT5_LIB_LOCATION} DIRECTORY)
 	
@@ -49,14 +43,12 @@ include_directories(${Qt5OpenGL_INCLUDE_DIRS}
 # ------------------------------------------------------------------------------
 # OpenGL
 # ------------------------------------------------------------------------------
-
-#find_package( OpenGL REQUIRED )
-#if( NOT OPENGL_FOUND )
-#    message( SEND_ERROR "OpenGL required, but not found with 'find_package()'" )
-#endif()
-
-#include_directories(${OpenGL_INCLUDE_DIR})
-
+if ( MSVC )
+	# Where to find OpenGL libraries
+	set(WINDOWS_OPENGL_LIBS "C:\\Program Files (x86)\\Windows Kits\\8.0\\Lib\\win8\\um\\x64" CACHE PATH "WindowsSDK libraries" )
+	list( APPEND CMAKE_PREFIX_PATH ${WINDOWS_OPENGL_LIBS} )
+endif()
+				
 # ------------------------------------------------------------------------------
 # OpenMP
 # ------------------------------------------------------------------------------

--- a/CMakeExternalLibs.cmake
+++ b/CMakeExternalLibs.cmake
@@ -7,9 +7,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 set( QT5_ROOT_PATH CACHE PATH "Qt5 root directory (i.e. where the 'bin' folder lies)" )
 if ( QT5_ROOT_PATH )
-
 	list( APPEND CMAKE_PREFIX_PATH ${QT5_ROOT_PATH} )
-	
 endif()
 
 # find qt5 components
@@ -25,11 +23,20 @@ find_package(Qt5OpenGLExtensions)
 # in the case no Qt5Config.cmake file could be found, cmake will explicitly ask the user for the QT5_DIR containing it!
 # thus no need to keep additional variables and checks
 
+# Starting with the QtCore lib, find the bin and root directories
 get_target_property(QT5_LIB_LOCATION Qt5::Core LOCATION_${CMAKE_BUILD_TYPE})
 get_filename_component(QT_BINARY_DIR ${QT5_LIB_LOCATION} DIRECTORY)
-	
+
+# Apple uses frameworks - move up until we get to the base directory to set the bin directory properly
+if ( APPLE )
+	get_filename_component(QT_BINARY_DIR ${QT_BINARY_DIR} DIRECTORY)
+	get_filename_component(QT_BINARY_DIR ${QT_BINARY_DIR} DIRECTORY)
+	set(QT_BINARY_DIR "${QT_BINARY_DIR}/bin")
+endif()
+
+# set QT5_ROOT_PATH if it wasn't set by the user
 if ( NOT QT5_ROOT_PATH )
-	set(QT5_ROOT_PATH ${QT_BINARY_DIR}/../)
+	get_filename_component(QT5_ROOT_PATH ${QT_BINARY_DIR} DIRECTORY)
 endif()
 
 include_directories(${Qt5OpenGL_INCLUDE_DIRS}

--- a/ccViewer/CMakeLists.txt
+++ b/ccViewer/CMakeLists.txt
@@ -34,8 +34,8 @@ if ( ${OPTION_SUPPORT_3DCONNEXION_DEVICES} )
 	list( APPEND source_list ${3DX_source_list} )
 endif()	
 
-qt_wrap_ui( generated_ui_list ${ui_list} )
-qt_add_resources( generated_qrc_list ${qrc_list} )
+qt5_wrap_ui( generated_ui_list ${ui_list} )
+qt5_add_resources( generated_qrc_list ${qrc_list} )
 
 # App icon with MSVC
 if( MSVC )

--- a/libs/qCC_glWindow/ccGLWindow.h
+++ b/libs/qCC_glWindow/ccGLWindow.h
@@ -301,7 +301,7 @@ public:
 	virtual const void setBaseViewMat(ccGLMatrixd& mat);
 
 	//! Returns the current OpenGL camera parameters
-	virtual void getGLCameraParameters(ccGLCameraParameters& params);
+	virtual void getGLCameraParameters(ccGLCameraParameters& params) override;
 
 	//! Sets camera to a predefined view (top, bottom, etc.)
 	virtual void setView(CC_VIEW_ORIENTATION orientation, bool redraw = true);
@@ -567,7 +567,7 @@ public slots:
 	void zoomGlobal();
 
 	//inherited from ccGenericGLDisplay
-	virtual void redraw(bool only2D = false, bool resetLOD = true);
+	virtual void redraw(bool only2D = false, bool resetLOD = true) override;
 
 	//called when recieving mouse wheel is rotated
 	void onWheelEvent(float wheelDelta_deg);
@@ -790,17 +790,17 @@ protected: //other methods
 	void setFontPointSize(int pixelSize);
 
 	//events handling
-	void mousePressEvent(QMouseEvent *event);
-	void mouseMoveEvent(QMouseEvent *event);
-	void mouseReleaseEvent(QMouseEvent *event);
-	void wheelEvent(QWheelEvent *event);
-	void closeEvent(QCloseEvent *event);
+	void mousePressEvent(QMouseEvent *event) override;
+	void mouseMoveEvent(QMouseEvent *event) override;
+	void mouseReleaseEvent(QMouseEvent *event) override;
+	void wheelEvent(QWheelEvent *event) override;
+	void closeEvent(QCloseEvent *event) override;
 
 	//inherited
-	void initializeGL();
-	void resizeGL(int w, int h);
-	void paintGL();
-	bool event(QEvent* evt);
+	void initializeGL() override;
+	void resizeGL(int w, int h) override;
+	void paintGL() override;
+	bool event(QEvent* evt) override;
 
 	//Graphical features controls
 	void drawCross();
@@ -826,8 +826,8 @@ protected: //other methods
 	void drawPivot();
 
 	//inherited from QWidget (drag & drop support)
-	virtual void dragEnterEvent(QDragEnterEvent* event);
-	virtual void dropEvent(QDropEvent* event);
+	virtual void dragEnterEvent(QDragEnterEvent* event) override;
+	virtual void dropEvent(QDropEvent* event) override;
 
 	//! Picking parameters
 	struct PickingParameters

--- a/libs/qCC_io/CMakeLists.txt
+++ b/libs/qCC_io/CMakeLists.txt
@@ -23,7 +23,7 @@ if( ${OPTION_SUPPORT_MAC_PDMS_FORMAT} )
 	list( APPEND source_list ${PDMS_source_list} )
 endif()
 
-qt_wrap_ui( generated_ui_list ${ui_list} )
+qt5_wrap_ui( generated_ui_list ${ui_list} )
 add_library( ${PROJECT_NAME} SHARED ${header_list} ${source_list} ${moc_list} ${generated_ui_list} )
 
 target_link_libraries( ${PROJECT_NAME} CC_CORE_LIB )

--- a/plugins/CMakePluginTpl.cmake
+++ b/plugins/CMakePluginTpl.cmake
@@ -8,7 +8,7 @@ include_directories( ${CC_FBO_LIB_SOURCE_DIR}/include )
 include_directories( ${QCC_IO_LIB_SOURCE_DIR} )
 include_directories( ${QCC_DB_LIB_SOURCE_DIR} )
 if( MSVC )
-	include_directories( ${QCC_DB_LIB_SOURCE_DIR}/msvc )
+    include_directories( ${QCC_DB_LIB_SOURCE_DIR}/msvc )
 endif()
 include_directories( ${QCC_GL_LIB_SOURCE_DIR} )
 include_directories( ${EXTERNAL_LIBS_INCLUDE_DIR} )
@@ -22,20 +22,20 @@ file( GLOB qrc_list *.qrc )
 file( GLOB rc_list *.rc )
 
 if ( CC_PLUGIN_CUSTOM_HEADER_LIST )
-	list( APPEND header_list ${CC_PLUGIN_CUSTOM_HEADER_LIST} )
+    list( APPEND header_list ${CC_PLUGIN_CUSTOM_HEADER_LIST} )
 endif()
 
 if ( CC_PLUGIN_CUSTOM_SOURCE_LIST )
-	list( APPEND source_list ${CC_PLUGIN_CUSTOM_SOURCE_LIST} )
+    list( APPEND source_list ${CC_PLUGIN_CUSTOM_SOURCE_LIST} )
 endif()
 
 if (CC_PLUGIN_CUSTOM_UI_LIST)
-	list( APPEND ui_list ${CC_PLUGIN_CUSTOM_UI_LIST} )
+    list( APPEND ui_list ${CC_PLUGIN_CUSTOM_UI_LIST} )
 endif()
 
 
-qt_wrap_ui( generated_ui_list ${ui_list} )
-qt_add_resources( generated_qrc_list ${qrc_list} )
+qt5_wrap_ui( generated_ui_list ${ui_list} )
+qt5_add_resources( generated_qrc_list ${qrc_list} )
 
 add_library( ${PROJECT_NAME} SHARED ${header_list} ${source_list} ${moc_list} ${generated_ui_list} ${generated_qrc_list})
 
@@ -48,7 +48,7 @@ endif()
 if( NOT CMAKE_CONFIGURATION_TYPES )
     set_property( TARGET ${PROJECT_NAME} APPEND PROPERTY COMPILE_DEFINITIONS QT_NO_DEBUG )
 else()
-	set_property( TARGET ${PROJECT_NAME} APPEND PROPERTY COMPILE_DEFINITIONS_RELEASE QT_NO_DEBUG)
+    set_property( TARGET ${PROJECT_NAME} APPEND PROPERTY COMPILE_DEFINITIONS_RELEASE QT_NO_DEBUG)
 endif()
 
 target_link_libraries( ${PROJECT_NAME} CC_FBO_LIB )
@@ -63,53 +63,49 @@ qt5_use_modules(${PROJECT_NAME} Core Gui Widgets OpenGL Concurrent)
 if( APPLE )
     # put all the plugins we build into one directory
     set( PLUGINS_OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/../../ccPlugins" )
-    
+
     file( MAKE_DIRECTORY "${PLUGINS_OUTPUT_DIR}" )
-    
+
     set_target_properties( ${PROJECT_NAME}
         PROPERTIES
         LIBRARY_OUTPUT_DIRECTORY "${PLUGINS_OUTPUT_DIR}"
     )
-	
-	install( TARGETS ${PROJECT_NAME} LIBRARY DESTINATION ${CLOUDCOMPARE_MAC_BASE_DIR}/Contents/Plugins/ccPlugins COMPONENT Runtime )
-	set( CLOUDCOMPARE_PLUGINS ${CLOUDCOMPARE_PLUGINS} ${CLOUDCOMPARE_MAC_BASE_DIR}/Contents/Plugins/ccPlugins/lib${PROJECT_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX} CACHE INTERNAL "CloudCompare plugin list")
+
+    install( TARGETS ${PROJECT_NAME} LIBRARY DESTINATION ${CLOUDCOMPARE_MAC_BASE_DIR}/Contents/Plugins/ccPlugins COMPONENT Runtime )
+    set( CLOUDCOMPARE_PLUGINS ${CLOUDCOMPARE_PLUGINS} ${CLOUDCOMPARE_MAC_BASE_DIR}/Contents/Plugins/ccPlugins/lib${PROJECT_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX} CACHE INTERNAL "CloudCompare plugin list")
 else()
-	install_shared( ${PROJECT_NAME} ${CLOUDCOMPARE_DEST_FOLDER} 1 /plugins )
+    install_shared( ${PROJECT_NAME} ${CLOUDCOMPARE_DEST_FOLDER} 1 /plugins )
 endif()
 
 #GL filters and IO plugins also go the the ccViewer 'plugins' sub-folder
 if( ${OPTION_BUILD_CCVIEWER} )
-
-	if( CC_SHADER_FOLDER OR CC_IS_IO_PLUGIN )
-		if( APPLE )
-			install( TARGETS ${PROJECT_NAME} LIBRARY DESTINATION ${CCVIEWER_MAC_BASE_DIR}/Contents/Plugins/ccViewerPlugins COMPONENT Runtime )
-			set( CCVIEWER_PLUGINS ${CCVIEWER_PLUGINS} ${CCVIEWER_MAC_BASE_DIR}/Contents/Plugins/ccViewerPlugins/lib${PROJECT_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX} CACHE INTERNAL "ccViewer plugin list")
-		else()
-			install_shared( ${PROJECT_NAME} ${CCVIEWER_DEST_FOLDER} 1 /plugins )
-		endif()
-	endif()
-
+    if( CC_SHADER_FOLDER OR CC_IS_IO_PLUGIN )
+        if( APPLE )
+            install( TARGETS ${PROJECT_NAME} LIBRARY DESTINATION ${CCVIEWER_MAC_BASE_DIR}/Contents/Plugins/ccViewerPlugins COMPONENT Runtime )
+            set( CCVIEWER_PLUGINS ${CCVIEWER_PLUGINS} ${CCVIEWER_MAC_BASE_DIR}/Contents/Plugins/ccViewerPlugins/lib${PROJECT_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX} CACHE INTERNAL "ccViewer plugin list")
+        else()
+            install_shared( ${PROJECT_NAME} ${CCVIEWER_DEST_FOLDER} 1 /plugins )
+        endif()
+    endif()
 endif()
 
 #'GL filter' plugins specifics
 if( CC_SHADER_FOLDER )
-
-	#copy the shader files
-	file( GLOB shaderFiles shaders/${CC_SHADER_FOLDER}/*.frag shaders/${CC_SHADER_FOLDER}/*.vert )
-	foreach( filename ${shaderFiles} )
-		if( APPLE )
-			install( FILES ${filename} DESTINATION ${CLOUDCOMPARE_MAC_BASE_DIR}/Contents/Shaders/${CC_SHADER_FOLDER} )
-			if( ${OPTION_BUILD_CCVIEWER} )
-				install( FILES ${filename} DESTINATION ${CCVIEWER_MAC_BASE_DIR}/Contents/Shaders/${CC_SHADER_FOLDER} )
-			endif()
-		else()
-			install_ext( FILES ${filename} ${CLOUDCOMPARE_DEST_FOLDER} /shaders/${CC_SHADER_FOLDER} )
-			if( ${OPTION_BUILD_CCVIEWER} )
-				install_ext( FILES ${filename} ${CCVIEWER_DEST_FOLDER} /shaders/${CC_SHADER_FOLDER} )
-			endif()
-		endif()
-	endforeach()
-
+    #copy the shader files
+    file( GLOB shaderFiles shaders/${CC_SHADER_FOLDER}/*.frag shaders/${CC_SHADER_FOLDER}/*.vert )
+    foreach( filename ${shaderFiles} )
+        if( APPLE )
+            install( FILES ${filename} DESTINATION ${CLOUDCOMPARE_MAC_BASE_DIR}/Contents/Shaders/${CC_SHADER_FOLDER} )
+            if( ${OPTION_BUILD_CCVIEWER} )
+                install( FILES ${filename} DESTINATION ${CCVIEWER_MAC_BASE_DIR}/Contents/Shaders/${CC_SHADER_FOLDER} )
+            endif()
+        else()
+            install_ext( FILES ${filename} ${CLOUDCOMPARE_DEST_FOLDER} /shaders/${CC_SHADER_FOLDER} )
+            if( ${OPTION_BUILD_CCVIEWER} )
+                install_ext( FILES ${filename} ${CCVIEWER_DEST_FOLDER} /shaders/${CC_SHADER_FOLDER} )
+            endif()
+        endif()
+    endforeach()
 endif()
 
 ### END OF DEFAULT CC PLUGIN CMAKE SCRIPT ###

--- a/plugins/qRANSAC_SD/RANSAC_SD_orig/CMakeLists.txt
+++ b/plugins/qRANSAC_SD/RANSAC_SD_orig/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 
 add_subdirectory( MiscLib )
 

--- a/qCC/CMakeLists.txt
+++ b/qCC/CMakeLists.txt
@@ -34,8 +34,8 @@ file( GLOB qrc_list *.qrc )
 
 file( GLOB txt_list TODO.txt bin_other/history.txt )
 
-qt_wrap_ui( generated_ui_list ${ui_list} )
-qt_add_resources( generated_qrc_list ${qrc_list} )
+qt5_wrap_ui( generated_ui_list ${ui_list} )
+qt5_add_resources( generated_qrc_list ${qrc_list} )
 
 # App icon with MSVC
 if( MSVC )

--- a/qCC/CMakeLists.txt
+++ b/qCC/CMakeLists.txt
@@ -59,11 +59,9 @@ target_link_libraries( ${PROJECT_NAME} QCC_GL_LIB )
 target_link_libraries( ${PROJECT_NAME} qcustomplot )
 
 # Qt
+qt5_use_modules(${PROJECT_NAME} Core Gui Widgets OpenGL PrintSupport)
 if (WIN32)
-    qt5_use_modules(${PROJECT_NAME} Core Gui Widgets OpenGL PrintSupport)
 	target_link_libraries( ${PROJECT_NAME} Qt5::WinMain )
-else()
-	qt5_use_modules(${PROJECT_NAME} Core Gui Widgets OpenGL PrintSupport)
 endif()
 
 # contrib. libraries support

--- a/qCC/ccRenderToFileDlg.cpp
+++ b/qCC/ccRenderToFileDlg.cpp
@@ -53,7 +53,7 @@ ccRenderToFileDlg::ccRenderToFileDlg(unsigned baseWidth, unsigned baseHeight, QW
 	for (int i=0; i<list.size(); ++i)
 	{
 		filters.append(QString("%1 image (*.%2)\n").arg(QString(list[i].data()).toUpper()).arg(list[i].data()));
-		if (i == 0 || list[i].data() == "jpg")
+		if (i == 0 || QString(list[i].data()) == "jpg")
 		{
 			firstFilter = filters;
 		}


### PR DESCRIPTION
- add override specs to ccGLWindow to silence warnings
- bug fix (render to file): can't compare two (char *)s
- {cmake} remove qt4 -> qt5 wrappers
- {cmake} quiet down the OpenMP search...
- {cmake} move Windows OpenGL stuff to the OpenGL section
- {cmake} {Mac} set the QT_BINARY_DIR properly (accounting for Frameworks)
- {cmake} other cleanups