### PR TITLE
fixed qPCL plugin's cmakelist file for qt5

### DIFF
--- a/plugins/qPCL/PclUtils/CMakeLists.txt
+++ b/plugins/qPCL/PclUtils/CMakeLists.txt
@@ -26,8 +26,13 @@ file( GLOB_RECURSE source_list *.cpp )
 file( GLOB_RECURSE impl_list *.hpp)
 file( GLOB_RECURSE ui_list *.ui )
 
+if(QT_UIC_EXECUTABLE)
+	message(STATUS "QT_UIC_EXECUTABLE is OK")
+else()
+	message(FATAL_ERROR "QT_UIC_EXECUTABLE is not set. Please set it to point to the uic.exe from the QT5 folder.")
+endif()
 
-qt_wrap_ui(generated_ui_list ${ui_list})
+qt5_wrap_ui(generated_ui_list ${ui_list})
 
 add_library( ${PROJECT_NAME} STATIC ${header_list} ${source_list} ${impl_list} ${moc_list} ${generated_ui_list} )
 


### PR DESCRIPTION
As discussed on the forum: [](http://www.cloudcompare.org/forum/viewtopic.php?f=10&t=1650&p=6433&sid=4e9146eb3770e151bfb5504d81700e11#p6433)
It may break the compatibility with QT4, but it was failing for me.