### PR TITLE
Linux/Unix build

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -35,7 +35,7 @@
   - on the first run you may have to manually set the **QT5_ROOT_PATH** variable. Make it point to your installation of Qt (on Windows it's where the 'bin' folder lies - e.g. *Qt\5.6\msvc2013_64*)
 
 2. Before clicking on the 'Generate' button, you may want to set some more options. If you expand the `OPTION` group, you'll be able to set some general options:
-  - `OPTION_BUILD_CC_VIEWER`: whether or not to build the ccViewer side project (on by default)
+  - `OPTION_BUILD_CC_VIEWER`: whether or not to build the ccViewer side project (ON by default)
   - `OPTION_SUPPORT_MAC_PDMS_FORMAT`: to add support for PDMS .mac scripts (*CAD format*)
   - `OPTION_USE_DXFLIB`: to add support for DXF files in CloudCompare/ccViewer with **dxflib** - see [below](#optional-setup-for-dxflib-support)
   - `OPTION_USE_FBX_SDK`: to add support for FBX files in CloudCompare/ccViewer with the official **FBX SDK** - see [below](#optional-setup-for-fbx-sdk-support)
@@ -64,7 +64,7 @@
   - qPCL (requires PCL - see [below](#optional-setup-for-pcl-required-by-qpcl))
   - qPCV
   - qPoissonRecon *(note: be sure to update the PoissonRecon submodule - see above)*
-  - qRansacSD *(only tested on Windows)*
+  - qRansacSD *(mainly tested on Windows but works with flaws on Linux)*
   - qSRA
   - qSSAO
 
@@ -97,13 +97,6 @@ The Mac OS X install/release process is still a bit less automated than the othe
 As all the files (executables, plugins and other DLLs) are copied in the `CMAKE_INSTALL_PREFIX` directory, the standard project launch/debug mechanism is broken. Therefore by default you won't be able to 'run' the CloudCompare or ccViewer projects as is (with F5 or Ctrl + F5 for instance). See [this post](http://www.danielgm.net/cc/forum/viewtopic.php?t=992) on the forum to setup Visual correctly.
 
 # Appendix
-
-## Common issues
-
-On Linux, you may encounter issues with shared libraries (.so files) if the project is not installed in `/usr`. In this case:
-
-1. either set the `LD_LIBRARY_PATH` variable so that it points to the qCC and ccViewer installation folders (`export LD_LIBRARY_PATH=...`).
-2. or call  `# /sbin/ldconfig -v` once as suggested [here](http://www.danielgm.net/cc/forum/viewtopic.php?f=10&t=195&p=602#p600)
 
 ## Additional optional CMake setup steps
 

--- a/CC/CGALSupport.cmake
+++ b/CC/CGALSupport.cmake
@@ -12,16 +12,16 @@ if (CGAL_FOUND)
 	include( ${CGAL_USE_FILE} )
 	include_directories(${CGAL_INCLUDE_DIR})
 	
-	#take care of GMP and MPFR DLLs on Windows!
+	# Take care of GMP and MPFR DLLs on Windows!
 	if( WIN32 )
-		#message(${GMP_LIBRARIES})
+		# message(${GMP_LIBRARIES})
 		list(GET GMP_LIBRARIES 0 FIRST_GMP_LIB_FILE)
 		get_filename_component(GMP_LIB_FOLDER ${FIRST_GMP_LIB_FILE} DIRECTORY)
-		#message(${GMP_LIB_FOLDER})
+		# message(${GMP_LIB_FOLDER})
 
 		file( GLOB GMP_DLL_FILES ${GMP_LIB_FOLDER}/*.dll )
 		foreach( dest ${INSTALL_DESTINATIONS} )
-			copy_files( "${GMP_DLL_FILES}" ${dest} ) #mind the quotes!
+			copy_files( "${GMP_DLL_FILES}" ${dest} ) # Mind the quotes!
 		endforeach()
 	endif()
 

--- a/CC/CGALSupport.cmake
+++ b/CC/CGALSupport.cmake
@@ -8,10 +8,13 @@ if (CGAL_FOUND)
 	if(${CGAL_MAJOR_VERSION}.${CGAL_MINOR_VERSION} LESS 4.3)
 		message(SEND_ERROR "CC Lib requires at least CGAL 4.3")
 	endif()
-	
+
+  	# We need to get ride of CGAL CXX flags
+  	set(CGAL_DONT_OVERRIDE_CMAKE_FLAGS ON CACHE INTERNAL "override CGAL flags" FORCE)
+
 	include( ${CGAL_USE_FILE} )
 	include_directories(${CGAL_INCLUDE_DIR})
-	
+
 	# Take care of GMP and MPFR DLLs on Windows!
 	if( WIN32 )
 		# message(${GMP_LIBRARIES})

--- a/CC/CMakeLists.txt
+++ b/CC/CMakeLists.txt
@@ -9,7 +9,7 @@ option( COMPILE_CC_CORE_LIB_WITH_CGAL "Check to compile CC_CORE_LIB with CGAL li
 option( COMPILE_CC_CORE_LIB_SHARED "Check to compile CC_CORE_LIB as a shared library (DLL/so)" ON )
 
 # to compile CCLib only! (CMake implicitly imposes to declare a project before anything...)
-project( CC_DUMMY_PROJECT )
+project( CC_CORE_LIB VERSION 1.0 )
 
 # CGAL takes precedence over triangle
 if (COMPILE_CC_CORE_LIB_WITH_CGAL)
@@ -20,8 +20,6 @@ endif()
 if (COMPILE_CC_CORE_LIB_WITH_QT)
 	include( ../CMakeExternalLibs.cmake )
 endif()
-
-project( CC_CORE_LIB VERSION 1.0 )
 
 include_directories( ${CMAKE_CURRENT_SOURCE_DIR}/include )
 if( MSVC )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,6 @@ if (APPLE)
 	set( CMAKE_SKIP_BUILD_RPATH  FALSE )
 	set( CMAKE_BUILD_WITH_INSTALL_RPATH FALSE ) 
 	set( CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE )
-elseif( UNIX )
-  SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib/cloudcompare")
 endif()
 
 include ( CMakePolicies.cmake )
@@ -32,6 +30,12 @@ endif()
 # Default install folders
 # (on Windows - msvc generator - the '_debug' suffix is automatically added for debug configurations)
 set( INSTALL_DESTINATIONS CloudCompare )
+
+# RPATH Linux/Unix: (dynamic) libs are put in a subdir of prefix/lib,
+# since they are only used by qCC/ccViewer
+if( UNIX AND NOT APPLE)
+	set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib/cloudcompare")
+endif()
 
 # CCViewer
 OPTION( OPTION_BUILD_CCVIEWER "Check to compile CCViewer project" ON )


### PR DESCRIPTION
This PR intends to fix 2 issue in cmake build for Unix systems
- RPATH was not well defined
- CGAL used to erase our CXX flags at configuration time