### PR TITLE
introduces regex-selection of tree objects

### DIFF
--- a/qCC/ccSelectChildrenDlg.cpp
+++ b/qCC/ccSelectChildrenDlg.cpp
@@ -22,6 +22,7 @@ static bool s_lastNameState = false;
 static CC_CLASS_ENUM s_lastType = CC_TYPES::POINT_CLOUD;
 static bool s_lastTypeState = true;
 static bool s_lastTypeStrictState = true;
+static bool s_lastUseRegex = true;
 
 ccSelectChildrenDlg::ccSelectChildrenDlg(QWidget* parent/*=0*/)
 	: QDialog(parent, Qt::Tool)
@@ -33,6 +34,7 @@ ccSelectChildrenDlg::ccSelectChildrenDlg(QWidget* parent/*=0*/)
 	typeStrictCheckBox->setChecked(s_lastTypeStrictState);
 	nameCheckBox->setChecked(s_lastNameState);
 	nameLineEdit->setText(s_lastName);
+	checkBoxRegex->setChecked(s_lastUseRegex);
 
 	connect(buttonBox, SIGNAL(accepted()), this, SLOT(onAccept()));
 }
@@ -53,6 +55,7 @@ void ccSelectChildrenDlg::onAccept()
 	s_lastTypeState = typeCheckBox->isChecked();
 	s_lastTypeStrictState = typeCheckBox->isChecked();
 	s_lastType = getSelectedType();
+	s_lastUseRegex = getNameIsRegex();
 }
 
 CC_CLASS_ENUM ccSelectChildrenDlg::getSelectedType()
@@ -72,7 +75,22 @@ QString ccSelectChildrenDlg::getSelectedName()
 	return nameLineEdit->text();
 }
 
-bool ccSelectChildrenDlg::getStrictMatchState()
+bool ccSelectChildrenDlg::getStrictMatchState() const
 {
 	return typeStrictCheckBox->isChecked();
+}
+
+bool ccSelectChildrenDlg::getTypeIsUsed() const
+{
+	return typeCheckBox->isChecked();
+}
+
+bool ccSelectChildrenDlg::getNameIsRegex() const
+{
+	return checkBoxRegex->isChecked();
+}
+
+bool ccSelectChildrenDlg::getNameMatchIsUsed() const
+{
+	return nameCheckBox->isChecked();
 }

--- a/qCC/ccSelectChildrenDlg.h
+++ b/qCC/ccSelectChildrenDlg.h
@@ -44,7 +44,17 @@ public:
 	//! Returns the selected name (if any)
 	QString getSelectedName();
 	//! Returns the state of the strict type checkbox
-	bool getStrictMatchState();
+	bool getStrictMatchState() const;
+
+	//! if the type checkbox is checked the children are filtered
+	//! before checking the name for matches
+	bool getTypeIsUsed() const;
+
+	//! if the name must be considerd as regex
+	bool getNameIsRegex() const;
+
+	//! if performing name-match (regex or not)
+	bool getNameMatchIsUsed() const;
 
 protected slots:
 

--- a/qCC/db_tree/ccDBRoot.cpp
+++ b/qCC/db_tree/ccDBRoot.cpp
@@ -1725,7 +1725,7 @@ void ccDBRoot::selectByTypeAndName()
 
 	// for name matching - def values
 	bool regex = false;
-	QString name (""); // an empty string by default
+	QString name; // an empty string by default
 
 	if (scDlg.getNameMatchIsUsed())
 	{

--- a/qCC/db_tree/ccDBRoot.cpp
+++ b/qCC/db_tree/ccDBRoot.cpp
@@ -1725,7 +1725,7 @@ void ccDBRoot::selectByTypeAndName()
 
 	// for name matching - def values
 	bool regex = false;
-	QString name = "";
+	QString name (""); // an empty string by default
 
 	if (scDlg.getNameMatchIsUsed())
 	{

--- a/qCC/db_tree/ccDBRoot.h
+++ b/qCC/db_tree/ccDBRoot.h
@@ -238,7 +238,10 @@ protected:
 	void expandOrCollapseHoveredBranch(bool expand);
 
 	//! Selects objects by type and/or name
-	void selectChildrenByTypeAndName(CC_CLASS_ENUM type, bool typeIsExclusive = true, QString name = QString());
+    void selectChildrenByTypeAndName(CC_CLASS_ENUM type,
+                                     bool typeIsExclusive = true,
+                                     QString name = QString(),
+                                     bool nameIsRegex = false);
 
 	//! Associated DB root
 	ccHObject* m_treeRoot;

--- a/qCC/ui_templates/selectChildrenDlg.ui
+++ b/qCC/ui_templates/selectChildrenDlg.ui
@@ -52,16 +52,25 @@
          <enum>QFrame::Raised</enum>
         </property>
         <layout class="QHBoxLayout" name="horizontalLayout">
-         <property name="margin">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
           <number>0</number>
          </property>
          <item>
           <widget class="QLineEdit" name="nameLineEdit"/>
          </item>
          <item>
-          <widget class="QLabel" name="label_2">
+          <widget class="QCheckBox" name="checkBoxRegex">
            <property name="text">
-            <string>(case sensitive)</string>
+            <string>regex</string>
            </property>
           </widget>
          </item>
@@ -80,7 +89,16 @@
          <enum>QFrame::Raised</enum>
         </property>
         <layout class="QHBoxLayout" name="horizontalLayout_6">
-         <property name="margin">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
           <number>0</number>
          </property>
          <item>


### PR DESCRIPTION
this should be a better version, let me know if anybody sees problems with it 

- some line indentation cleaning 
- possibility to use regex for name matching
- when not using object name matching nor type matching all the objects are selected
- one can now select all custom types (e.g. objects from plugins)