### PR TITLE
Bug fix: OpenGL rendering on retina displays

### DIFF
--- a/libs/qCC_glWindow/ccGLWindow.cpp
+++ b/libs/qCC_glWindow/ccGLWindow.cpp
@@ -141,6 +141,10 @@ void ccGLWindow::removeFBOSafe(ccFrameBufferObject* &fbo)
 
 bool ccGLWindow::initFBOSafe(ccFrameBufferObject* &fbo, int w, int h)
 {
+	const qreal retinaScale = devicePixelRatio();
+	w *= retinaScale;
+	h *= retinaScale;
+
 	if (fbo && fbo->width() == w && fbo->height() == h)
 	{
 		//nothing to do
@@ -5709,6 +5713,9 @@ bool ccGLWindow::initGLFilter(int w, int h, bool silent/*=false*/)
 	}
 
 	makeCurrent();
+	const qreal retinaScale = devicePixelRatio();
+	w *= retinaScale;
+	h *= retinaScale;
 
 	//we "disconnect" current glFilter, to avoid wrong display/errors
 	//if QT tries to redraw window during initialization


### PR DESCRIPTION
Wrongly sized display buffers generated a wrong view
onto the scene. Therefore, all 3D interactions were not in
sync with the internal modelview matrix.