### PR TITLE
* Modified Color banding frequency to period Color banding.

### DIFF
--- a/libs/qCC_db/ccPointCloud.cpp
+++ b/libs/qCC_db/ccPointCloud.cpp
@@ -1476,7 +1476,7 @@ bool ccPointCloud::colorize(float r, float g, float b)
 }
 
 //Contribution from Michael J Smith
-bool ccPointCloud::setRGBColorByBanding(unsigned char dim, int freq)
+bool ccPointCloud::setRGBColorByBanding(unsigned char dim, double freq)
 {
 	if (freq == 0 || dim > 2) //X=0, Y=1, Z=2
 	{
@@ -1492,24 +1492,17 @@ bool ccPointCloud::setRGBColorByBanding(unsigned char dim, int freq)
 	enableTempColor(false);
 	assert(m_rgbColors);
 
- 	double minHeight = getOwnBB().minCorner().u[dim];
-	double height = getOwnBB().getDiagVec().u[dim];
-	
-	if (fabs(height) < ZERO_TOLERANCE) //flat cloud!
-		height = 1.0;
-
-	/* Repeats per spacing of 1 */
-	double bands = freq * (2 * M_PI);
+	float bands = (2.0 * M_PI) / freq;
 
 	unsigned count = size();
 	for (unsigned i=0; i<count; i++)
 	{
 		const CCVector3* P = getPoint(i);
 
-		double z = bands * (P->u[dim] - minHeight) / height;
-		ccColor::Rgb C(	static_cast<ColorCompType>( ((sin(z + 0) + 1.0) / 2.0) * ccColor::MAX ),
-						static_cast<ColorCompType>( ((sin(z + 2) + 1.0) / 2.0) * ccColor::MAX ),
-						static_cast<ColorCompType>( ((sin(z + 4) + 1.0) / 2.0) * ccColor::MAX ) );
+		float z = bands * P->u[dim];
+		ccColor::Rgb C(	static_cast<ColorCompType>( ((sin(z + 0.0f) + 1.0f) / 2.0f) * ccColor::MAX ),
+						static_cast<ColorCompType>( ((sin(z + 2.0944f) + 1.0f) / 2.0f) * ccColor::MAX ),
+						static_cast<ColorCompType>( ((sin(z + 4.1888f) + 1.0f) / 2.0f) * ccColor::MAX ) );
 
 		m_rgbColors->setValue(i,C.rgb);
 	}

--- a/libs/qCC_db/ccPointCloud.h
+++ b/libs/qCC_db/ccPointCloud.h
@@ -541,7 +541,7 @@ public: //other methods
 		\param freq banding frequency
 		\return success
 	**/
-	bool setRGBColorByBanding(unsigned char dim, int freq);
+	bool setRGBColorByBanding(unsigned char dim, double freq);
 
 	//! Sets RGB colors with current scalar field (values & parameters)
 	/** \return success

--- a/qCC/ccColorGradientDlg.cpp
+++ b/qCC/ccColorGradientDlg.cpp
@@ -30,7 +30,7 @@
 QColor s_firstColor(Qt::black);
 QColor s_secondColor(Qt::white);
 ccColorGradientDlg::GradientType s_lastType(ccColorGradientDlg::Default);
-static int s_lastFreq = 5;
+static double s_lastFreq = 1.0;
 
 ccColorGradientDlg::ccColorGradientDlg(QWidget* parent)
 	: QDialog(parent, Qt::Tool)
@@ -92,7 +92,7 @@ void ccColorGradientDlg::getColors(QColor& first, QColor& second) const
 	second = s_secondColor;
 }
 
-int ccColorGradientDlg::getBandingFrequency() const
+double ccColorGradientDlg::getBandingFrequency() const
 {
 	assert(bandingRadioButton->isChecked());
 	//ugly hack: we use 's_lastFreq' here as the frequency is only requested

--- a/qCC/ccColorGradientDlg.h
+++ b/qCC/ccColorGradientDlg.h
@@ -45,7 +45,7 @@ public:
 	void getColors(QColor& first, QColor& second) const;
 
 	//! Returns the frequency of the gradient ('Banding' mode)
-	int getBandingFrequency() const;
+	double getBandingFrequency() const;
 
 	//! Returns the ramp dimension
 	unsigned char getDimension() const;

--- a/qCC/ccCommandLineParser.cpp
+++ b/qCC/ccCommandLineParser.cpp
@@ -2420,10 +2420,10 @@ bool ccCommandLineParser::commandColorBanding(QStringList& arguments)
 
 	//frequency
 	bool ok = true;
-	int freq = 0;
+	double freq = 0;
 	{
 		QString countStr = arguments.takeFirst();
-		freq = countStr.toInt(&ok);
+		freq = countStr.toDouble(&ok);
 		if (!ok)
 			return Error(QString("Invalid parameter: frequency after \"-%1 DIM\" (in Hz, integer value)").arg(COMMAND_COLOR_BANDING));
 	}

--- a/qCC/ccEntityAction.cpp
+++ b/qCC/ccEntityAction.cpp
@@ -240,7 +240,7 @@ namespace ccEntityAction
 		
 		Q_ASSERT(colorScale || ramp == ccColorGradientDlg::Banding);
 		
-		const int	frequency = dlg.getBandingFrequency();
+		const double frequency = dlg.getBandingFrequency();
 		
 		size_t selNum = selectedEntities.size();
 		for (size_t i=0; i<selNum; ++i)


### PR DESCRIPTION
(This is how Mike Smith wanted this function to work)

Modified Color banding frequency to period:
+colour spectrum will repeat for each period. All clouds will use same colour scheme
-High max and min not used any more
+sine function changed to float and sine of 120 and 240 deg converted to radians with higher accuracy
+parameter frequency from int type to double
+updated UI dialog to double
+command line call frequency changed to double