### PR TITLE
Fix unconditional stereo buffer enabling.

### DIFF
--- a/qCC/main.cpp
+++ b/qCC/main.cpp
@@ -107,7 +107,6 @@ int main(int argc, char **argv)
 	{
 		QSurfaceFormat format = QSurfaceFormat::defaultFormat();
 		format.setSwapBehavior(QSurfaceFormat::DoubleBuffer);
-		format.setOption(QSurfaceFormat::StereoBuffers, true);
 		format.setStencilBufferSize(0);
 #ifdef CC_GL_WINDOW_USE_QWINDOW
 		format.setStereo(true);


### PR DESCRIPTION
Fix #406

Besides unconditional that enabling was redundant, three lines down an enabling controlled by CC_GL_WINDOW_USE_QWINDOW was present.

With this patch the stereo buffer is enabled in compile time by OPTION_GL_QUAD_BUFFER_SUPPORT cmake option.