### PR TITLE
Modified UI template - Color banding period:

### DIFF
--- a/qCC/ui_templates/colorGradientDlg.ui
+++ b/qCC/ui_templates/colorGradientDlg.ui
@@ -151,15 +151,18 @@
           </spacer>
          </item>
          <item>
-          <widget class="QSpinBox" name="bandingFreqSpinBox">
+          <widget class="QDoubleSpinBox" name="bandingFreqSpinBox">
            <property name="minimum">
-            <number>1</number>
+            <number>0.001</number>
            </property>
            <property name="maximum">
-            <number>1000000000</number>
+            <number>1000000000.0</number>
            </property>
            <property name="value">
             <number>5</number>
+           </property>
+           <property name="decimals">
+            <number>3</number>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
commit #425 I forgot to change UI template .ui file.
**bandingFreqSpinBox** changed from integer to double. Minimum decreased to 0.001 (we are using CC in um resolution).

I modified 'ui_colorGradientDlg.h' instead. It is my unfamiliarity with Qt.
My mod to .h were:
```
bandingFreqSpinBox = new QDoubleSpinBox(bandingFrame);
bandingFreqSpinBox->setObjectName(QStringLiteral("bandingFreqSpinBox"));
bandingFreqSpinBox->setMinimum(0.001);
bandingFreqSpinBox->setMaximum(1000000000.0);
bandingFreqSpinBox->setValue(5.0);
bandingFreqSpinBox->setDecimals(3);
```