### PR TITLE
Fixes compile warnings on Mac OS X

### DIFF
--- a/libs/qCC_db/ccWaveform.h
+++ b/libs/qCC_db/ccWaveform.h
@@ -30,8 +30,8 @@ public:
 
 	//inherited from ccSerializableObject
 	virtual bool isSerializable() const override { return true; }
-	virtual bool toFile(QFile& out) const;
-	virtual bool fromFile(QFile& in, short dataVersion, int flags);
+	virtual bool toFile(QFile& out) const override;
+	virtual bool fromFile(QFile& in, short dataVersion, int flags) override;
 
 	uint32_t numberOfSamples;	//!< Number of samples
 	uint32_t samplingRate_ps;	//!< Sampling rate in pico seconds
@@ -88,8 +88,8 @@ public:
 
 	//inherited from ccSerializableObject
 	virtual bool isSerializable() const override { return true; }
-	virtual bool toFile(QFile& out) const;
-	virtual bool fromFile(QFile& in, short dataVersion, int flags);
+	virtual bool toFile(QFile& out) const override;
+	virtual bool fromFile(QFile& in, short dataVersion, int flags) override;
 
 protected: //methods
 
@@ -99,7 +99,7 @@ protected: //methods
 protected: //members
 
 	//! Data buffer size (in bytes)
-	/** \waning Not necessarily equals to the number of samples!
+	/** \warning Not necessarily equal to the number of samples!
 	**/
 	uint32_t m_byteCount;
 

--- a/plugins/qAnimation/QTFFmpegWrapper/QVideoEncoder.cpp
+++ b/plugins/qAnimation/QTFFmpegWrapper/QVideoEncoder.cpp
@@ -265,7 +265,8 @@ bool QVideoEncoder::close()
 	// delayed frames?
 	while (true)
 	{
-		AVPacket pkt = { 0 };
+		AVPacket pkt;
+		memset( &pkt, 0, sizeof( AVPacket ) );		
 		av_init_packet(&pkt);
 
 		int got_packet = 0;
@@ -319,7 +320,8 @@ bool QVideoEncoder::encodeImage(const QImage &image, int frameIndex, QString* er
 		return false;
 	}
 
-	AVPacket pkt = { 0 };
+	AVPacket pkt;
+	memset( &pkt, 0, sizeof( AVPacket ) );
 	av_init_packet(&pkt);
 
 	// encode the image
@@ -406,7 +408,7 @@ bool QVideoEncoder::convertImage_sws(const QImage &image, QString* errorString/*
 		return false;
 	}
 
-	uint8_t *srcSlice[3] = { (uint8_t*)image.bits(), 0, 0 };
+	const uint8_t *srcSlice[3] = { static_cast<const uint8_t*>(image.constBits()), 0, 0 };
 	int srcStride[3] = { image.bytesPerLine(), 0, 0 };
 
 	sws_scale(	m_ff->swsContext,
@@ -419,4 +421,3 @@ bool QVideoEncoder::convertImage_sws(const QImage &image, QString* errorString/*
 
 	return true;
 }
-

--- a/qCC/mainwindow.h
+++ b/qCC/mainwindow.h
@@ -124,9 +124,9 @@ public:
 							bool checkDimensions = false,
 							bool autoRedraw = true) override;
 
-	virtual void registerOverlayDialog(ccOverlayDialog* dlg, Qt::Corner pos);
-	virtual void unregisterOverlayDialog(ccOverlayDialog* dlg);
-	virtual void updateOverlayDialogsPlacement();
+	virtual void registerOverlayDialog(ccOverlayDialog* dlg, Qt::Corner pos) override;
+	virtual void unregisterOverlayDialog(ccOverlayDialog* dlg) override;
+	virtual void updateOverlayDialogsPlacement() override;
 	virtual void removeFromDB(ccHObject* obj, bool autoDelete = true) override;
 	virtual void setSelectedInDB(ccHObject* obj, bool selected) override;
 	virtual void dispToConsole(QString message, ConsoleMessageLevel level = STD_CONSOLE_MESSAGE) override;


### PR DESCRIPTION
- override keyword missing
- spelling mistake in Doxygen command
- improper initialization of struct
- use of old-style cast (also made const)