### PR TITLE
add option to set last shift and scale info

### DIFF
--- a/libs/qCC_io/ccShiftAndScaleCloudDlg.cpp
+++ b/libs/qCC_io/ccShiftAndScaleCloudDlg.cpp
@@ -457,3 +457,18 @@ int ccShiftAndScaleCloudDlg::addShiftInfo(const ShiftInfo& info)
 
 	return static_cast<int>(m_defaultInfos.size())-1;
 }
+
+void ccShiftAndScaleCloudDlg::SetLastInfo(CCVector3d shift,double scale)
+{
+    try
+    {
+        s_lastInfo.valid = true;
+        s_lastInfo.shift = shift;
+        s_lastInfo.scale = scale;
+    }
+    catch (const std::bad_alloc&)
+    {
+        //not enough memory
+        return;
+    }
+}

--- a/libs/qCC_io/ccShiftAndScaleCloudDlg.h
+++ b/libs/qCC_io/ccShiftAndScaleCloudDlg.h
@@ -111,6 +111,9 @@ public:
 	//! Adds information from default file (if any)
 	bool addFileInfo();
 
+    //! Sets the last shift and scale information
+    static void SetLastInfo(CCVector3d shift,double scale);
+
 protected slots:
 
 	//! Slot called when the 'loadComboBox' index changes


### PR DESCRIPTION
add the option to update last shift and scale when using import through a plugin that needs to suppress the shfit&scale dialog. Discussions here

http://www.danielgm.net/cc/forum/viewtopic.php?f=3&t=2081&sid=b9cee2e0adfe4758ec3ab6be540d522b