### PR TITLE
Changes some default paths

### DIFF
--- a/ccViewer/main.cpp
+++ b/ccViewer/main.cpp
@@ -137,19 +137,19 @@ int main(int argc, char *argv[])
 	VLDEnable();
 #endif
 	
+	QDir  workingDir = QCoreApplication::applicationDirPath();
+	
 #ifdef Q_OS_MAC	
 	// This makes sure that our "working directory" is not within the application bundle
-	QDir  appDir = QCoreApplication::applicationDirPath();
-	
-	if ( appDir.dirName() == "MacOS" )
+	if ( workingDir.dirName() == "MacOS" )
 	{
-		appDir.cdUp();
-		appDir.cdUp();
-		appDir.cdUp();
-		
-		QDir::setCurrent( appDir.absolutePath() );
+		workingDir.cdUp();
+		workingDir.cdUp();
+		workingDir.cdUp();
 	}
 #endif
+	
+	QDir::setCurrent( workingDir.absolutePath() );
 	
 	if (!QGLFormat::hasOpenGL())
 	{

--- a/ccViewer/main.cpp
+++ b/ccViewer/main.cpp
@@ -19,9 +19,9 @@
 
 //Qt
 #include <QApplication>
+#include <QDir>
 #include <QGLFormat>
 #ifdef Q_OS_MAC
-#include <QDir>
 #include <QFileOpenEvent>
 #endif
 

--- a/libs/qCC_db/ccFileUtils.h
+++ b/libs/qCC_db/ccFileUtils.h
@@ -1,0 +1,32 @@
+#ifndef CCFILEUTILS_H
+#define CCFILEUTILS_H
+//##########################################################################
+//#                                                                        #
+//#                              CLOUDCOMPARE                              #
+//#                                                                        #
+//#  This program is free software; you can redistribute it and/or modify  #
+//#  it under the terms of the GNU General Public License as published by  #
+//#  the Free Software Foundation; version 2 or later of the License.      #
+//#                                                                        #
+//#  This program is distributed in the hope that it will be useful,       #
+//#  but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+//#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the          #
+//#  GNU General Public License for more details.                          #
+//#                                                                        #
+//#                    COPYRIGHT: CloudCompare project                     #
+//#                                                                        #
+//##########################################################################
+
+#include <QStandardPaths>
+#include <QString>
+
+namespace ccFileUtils
+{
+	//! Shortcut for getting the documents location path
+	inline QString	defaultDocPath()
+	{
+		// note that according to the docs the QStandardPaths::DocumentsLocation path is never empty
+		return QStandardPaths::standardLocations( QStandardPaths::DocumentsLocation ).first();
+	}
+}
+#endif

--- a/libs/qCC_io/ccShiftAndScaleCloudDlg.cpp
+++ b/libs/qCC_io/ccShiftAndScaleCloudDlg.cpp
@@ -25,8 +25,10 @@
 #include "ccGlobalShiftManager.h"
 
 //Qt
-#include <QPushButton>
+#include <QDebug>
+#include <QDir>
 #include <QFile>
+#include <QPushButton>
 #include <QTextStream>
 #include <QStringList>
 
@@ -151,9 +153,9 @@ void ccShiftAndScaleCloudDlg::displayMoreInfo()
 }
 
 bool ccShiftAndScaleCloudDlg::addFileInfo()
-{
+{	
 	//try to load the 'global_shift_list.txt" file
-	return loadInfoFromFile(QApplication::applicationDirPath() + QString("/")+ s_defaultGlobalShiftListFilename);
+	return loadInfoFromFile(QDir::currentPath() + QString("/")+ s_defaultGlobalShiftListFilename);
 }
 
 bool ccShiftAndScaleCloudDlg::loadInfoFromFile(QString filename)

--- a/plugins/qCSVMatrixIO/CSVMatrixOpenDialog.cpp
+++ b/plugins/qCSVMatrixIO/CSVMatrixOpenDialog.cpp
@@ -15,6 +15,8 @@
 //#                                                                        #
 //##########################################################################
 
+#include "ccFileUtils.h"
+
 #include "CSVMatrixOpenDialog.h"
 
 //Qt
@@ -33,7 +35,7 @@ CSVMatrixOpenDialog::CSVMatrixOpenDialog(QWidget* parent/*=0*/)
 	//persistent settings
 	QSettings settings;
 	settings.beginGroup("LoadFile");
-	QString currentPath = settings.value("currentPath",QApplication::applicationDirPath()).toString();
+	QString currentPath = settings.value("currentPath",ccFileUtils::defaultDocPath()).toString();
 
 	textureFilenameLineEdit->setText(currentPath);
 }

--- a/plugins/qFacets/qFacets.cpp
+++ b/plugins/qFacets/qFacets.cpp
@@ -35,6 +35,7 @@
 #include <QMessageBox>
 
 //qCC_db
+#include <ccFileUtils.h>
 #include <ccHObjectCaster.h>
 #include <ccProgressDialog.h>
 #include <ccScalarField.h>
@@ -683,7 +684,7 @@ void qFacets::exportFacets()
 	//persistent settings (default export path)
 	QSettings settings;
 	settings.beginGroup("qFacets");
-	QString facetsSavePath = settings.value("exportPath", QApplication::applicationDirPath()).toString();
+	QString facetsSavePath = settings.value("exportPath", ccFileUtils::defaultDocPath()).toString();
 	fDlg.destinationPathLineEdit->setText(facetsSavePath + QString("/facets.shp"));
 
 	if (!fDlg.exec())
@@ -1041,7 +1042,7 @@ void qFacets::exportFacetsInfo()
 	//persistent settings (default export path)
 	QSettings settings;
 	settings.beginGroup("qFacets");
-	QString facetsSavePath = settings.value("exportPath", QApplication::applicationDirPath()).toString();
+	QString facetsSavePath = settings.value("exportPath", ccFileUtils::defaultDocPath()).toString();
 	fDlg.destinationPathLineEdit->setText(facetsSavePath + QString("/facets.csv"));
 
 	if (!fDlg.exec())

--- a/plugins/qM3C2/qM3C2Dialog.cpp
+++ b/plugins/qM3C2/qM3C2Dialog.cpp
@@ -21,6 +21,7 @@
 #include "../ccMainAppInterface.h"
 
 //qCC_db
+#include <ccFileUtils.h>
 #include <ccPointCloud.h>
 
 //Qt
@@ -430,7 +431,7 @@ void qM3C2Dialog::loadParamsFromFile()
 	QString filename;
 	{
 		QSettings settings("qM3C2");
-		QString currentPath = settings.value("currentPath", QApplication::applicationDirPath()).toString();
+		QString currentPath = settings.value("currentPath", ccFileUtils::defaultDocPath()).toString();
 
 		filename = QFileDialog::getOpenFileName(this, "Load M3C2 parameters", currentPath, "*.txt");
 		if (filename.isEmpty())
@@ -461,7 +462,7 @@ void qM3C2Dialog::saveParamsToFile()
 	QString filename;
 	{
 		QSettings settings("qM3C2");
-		QString currentPath = settings.value("currentPath", QApplication::applicationDirPath()).toString();
+		QString currentPath = settings.value("currentPath", ccFileUtils::defaultDocPath()).toString();
 
 		filename = QFileDialog::getSaveFileName(this, "Save M3C2 parameters", currentPath + QString("/m3c2_params.txt"), "*.txt");
 		if (filename.isEmpty())

--- a/plugins/qSRA/distanceMapGenerationDlg.cpp
+++ b/plugins/qSRA/distanceMapGenerationDlg.cpp
@@ -35,6 +35,7 @@
 #include <ccRenderToFileDlg.h>
 
 //qCC_db
+#include <ccFileUtils.h>
 #include <ccPointCloud.h>
 #include <ccPlane.h>
 #include <ccScalarField.h>
@@ -1241,7 +1242,7 @@ void DistanceMapGenerationDlg::exportMapAsGrid()
 	//persistent settings (default export path)
 	QSettings settings;
 	settings.beginGroup("qSRA");
-	QString path = settings.value("exportPath",QApplication::applicationDirPath()).toString();
+	QString path = settings.value("exportPath", ccFileUtils::defaultDocPath()).toString();
 
 	QString filter("Grid file (*.csv)");
 
@@ -1402,7 +1403,7 @@ void DistanceMapGenerationDlg::loadOverlaySymbols()
 	//persistent settings (default import path)
 	QSettings settings;
 	settings.beginGroup("qSRA");
-	QString path = settings.value("importPath", QApplication::applicationDirPath()).toString();
+	QString path = settings.value("importPath", ccFileUtils::defaultDocPath()).toString();
 
 	QString filter("Symbols (*.txt)");
 

--- a/plugins/qSRA/dxfProfilesExportDlg.cpp
+++ b/plugins/qSRA/dxfProfilesExportDlg.cpp
@@ -15,6 +15,8 @@
 //#                                                                        #
 //##########################################################################
 
+#include "ccFileUtils.h"
+
 #include "dxfProfilesExportDlg.h"
 
 //Qt
@@ -43,8 +45,8 @@ void DxfProfilesExportDlg::initFromPersistentSettings()
 	QSettings settings;
 	settings.beginGroup("DxfProfilesExportDialog");
 
-	const QString	defaultVertProfile( QApplication::applicationDirPath() + "/vert_profiles.dxf" );
-	const QString	defaultHorizProfile( QApplication::applicationDirPath() + "/horiz_profiles.dxf" );
+	const QString	defaultVertProfile( ccFileUtils::defaultDocPath() + "/vert_profiles.dxf" );
+	const QString	defaultHorizProfile( ccFileUtils::defaultDocPath() + "/horiz_profiles.dxf" );
 	
 	//read parameters
 	bool vertEnabled		= settings.value("vertExportGroup",	true).toBool();

--- a/plugins/qSRA/qSRA.cpp
+++ b/plugins/qSRA/qSRA.cpp
@@ -32,6 +32,7 @@
 #include <QMainWindow>
 
 //qCC_db
+#include <ccFileUtils.h>
 #include <ccHObjectCaster.h>
 #include <ccPointCloud.h>
 #include <ccProgressDialog.h>
@@ -154,7 +155,7 @@ void qSRA::loadProfile() const
 	//persistent settings (default import path)
 	QSettings settings;
 	settings.beginGroup("qSRA");
-	QString path = settings.value("importPath",QApplication::applicationDirPath()).toString();
+	QString path = settings.value("importPath", ccFileUtils::defaultDocPath()).toString();
 
 	ProfileImportDlg piDlg(m_app->getMainWindow());
 	piDlg.setDefaultFilename(path);

--- a/qCC/bin_other/global_shift_list_template.txt
+++ b/qCC/bin_other/global_shift_list_template.txt
@@ -6,7 +6,7 @@
 // loading a file with big coordinates).
 //
 // All values are separated by a semicolon character (;):
-//    name; shift(X); shif(Y); shif(Z); scale;
+//    name; shift(X); shift(Y); shift(Z); scale;
 //
 // Example:
 //

--- a/qCC/ccApplyTransformationDlg.cpp
+++ b/qCC/ccApplyTransformationDlg.cpp
@@ -24,6 +24,7 @@
 #include "ui_dipDirTransformationDlg.h"
 
 //qCC_db
+#include <ccFileUtils.h>
 #include <ccNormalVectors.h>
 
 //Qt
@@ -255,7 +256,7 @@ void ccApplyTransformationDlg::loadFromASCIIFile()
 	//persistent settings
 	QSettings settings;
 	settings.beginGroup(ccPS::LoadFile());
-	QString currentPath = settings.value(ccPS::CurrentPath(),QApplication::applicationDirPath()).toString();
+	QString currentPath = settings.value(ccPS::CurrentPath(), ccFileUtils::defaultDocPath()).toString();
 
 	QString inputFilename = QFileDialog::getOpenFileName(this, "Select input file", currentPath, "*.txt");
 	if (inputFilename.isEmpty())

--- a/qCC/ccColorScaleEditorDlg.cpp
+++ b/qCC/ccColorScaleEditorDlg.cpp
@@ -25,6 +25,7 @@
 
 //qCC_db
 #include <ccColorScalesManager.h>
+#include <ccFileUtils.h>
 #include <ccScalarField.h>
 #include <ccPointCloud.h>
 
@@ -792,7 +793,7 @@ void ccColorScaleEditorDialog::exportCurrentScale()
 	//persistent settings
 	QSettings settings;
 	settings.beginGroup(ccPS::SaveFile());
-	QString currentPath = settings.value(ccPS::CurrentPath(),QApplication::applicationDirPath()).toString();
+	QString currentPath = settings.value(ccPS::CurrentPath(), ccFileUtils::defaultDocPath()).toString();
 
 	//ask for a filename
 	QString filename = QFileDialog::getSaveFileName(this,"Select output file",currentPath,"*.xml");
@@ -818,7 +819,7 @@ void ccColorScaleEditorDialog::importScale()
 	//persistent settings
 	QSettings settings;
 	settings.beginGroup(ccPS::LoadFile());
-	QString currentPath = settings.value(ccPS::CurrentPath(),QApplication::applicationDirPath()).toString();
+	QString currentPath = settings.value(ccPS::CurrentPath(), ccFileUtils::defaultDocPath()).toString();
 
 	//ask for a filename
 	QString filename = QFileDialog::getOpenFileName(this,"Select color scale file",currentPath,"*.xml");

--- a/qCC/ccCommandLineParser.cpp
+++ b/qCC/ccCommandLineParser.cpp
@@ -396,7 +396,7 @@ ccCommandLineParser::EntityDesc::EntityDesc(QString filename, int _indexInFile/*
 	if (filename.isNull())
 	{
 		basename = "unknown";
-		path = QApplication::applicationDirPath();
+		path = QDir::currentPath();
 	}
 	else
 	{
@@ -2245,7 +2245,7 @@ bool ccCommandLineParser::commandCrossSection(QStringList& arguments, QDialog* p
 					if (fromFiles)
 					{
 						assert(false);
-						outputDir = QDir(QCoreApplication::applicationDirPath());
+						outputDir = QDir::current();
 					}
 					else
 					{

--- a/qCC/ccHistogramWindow.cpp
+++ b/qCC/ccHistogramWindow.cpp
@@ -24,6 +24,8 @@
 
 //qCC_db
 #include <ccColorScalesManager.h>
+#include <ccFileUtils.h>
+
 //qCC_io
 #include <ImageFileFilter.h>
 
@@ -977,7 +979,7 @@ void ccHistogramWindowDlg::onExportToCSV()
 	//persistent settings
 	QSettings settings;
 	settings.beginGroup(ccPS::SaveFile());
-	QString currentPath = settings.value(ccPS::CurrentPath(), QApplication::applicationDirPath()).toString();
+	QString currentPath = settings.value(ccPS::CurrentPath(), ccFileUtils::defaultDocPath()).toString();
 
 	currentPath += QString("/") + m_win->windowTitle() + ".csv";
 
@@ -1008,7 +1010,7 @@ void ccHistogramWindowDlg::onExportToImage()
 	//persistent settings
 	QSettings settings;
 	settings.beginGroup(ccPS::SaveFile());
-	QString currentPath = settings.value(ccPS::CurrentPath(), QApplication::applicationDirPath()).toString();
+	QString currentPath = settings.value(ccPS::CurrentPath(), ccFileUtils::defaultDocPath()).toString();
 
 	QString outputFilename = ImageFileFilter::GetSaveFilename("Select output file",
 		m_win->windowTitle(),

--- a/qCC/ccRasterizeTool.cpp
+++ b/qCC/ccRasterizeTool.cpp
@@ -24,6 +24,7 @@
 #include "ccIsolines.h"
 
 //qCC_db
+#include <ccFileUtils.h>
 #include <ccGenericPointCloud.h>
 #include <ccPointCloud.h>
 #include <ccScalarField.h>
@@ -944,7 +945,7 @@ void ccRasterizeTool::generateRaster() const
 	{
 		QSettings settings;
 		settings.beginGroup(ccPS::HeightGridGeneration());
-		QString imageSavePath = settings.value("savePathImage", QApplication::applicationDirPath()).toString();
+		QString imageSavePath = settings.value("savePathImage", ccFileUtils::defaultDocPath()).toString();
 		outputFilename = QFileDialog::getSaveFileName(	const_cast<ccRasterizeTool*>(this),
 														"Save height grid raster",
 														imageSavePath + QString("/raster.tif"),
@@ -1882,7 +1883,7 @@ void ccRasterizeTool::generateImage() const
 		{
 			QSettings settings;
 			settings.beginGroup(ccPS::HeightGridGeneration());
-			QString imageSavePath = settings.value("savePathImage", QApplication::applicationDirPath()).toString();
+			QString imageSavePath = settings.value("savePathImage", ccFileUtils::defaultDocPath()).toString();
 
 			QString outputFilename = ImageFileFilter::GetSaveFilename(	"Save raster image",
 																		"raster_image",
@@ -1919,7 +1920,7 @@ void ccRasterizeTool::generateASCIIMatrix() const
 
 	QSettings settings;
 	settings.beginGroup(ccPS::HeightGridGeneration());
-	QString asciiGridSavePath = settings.value("savePathASCIIGrid", QApplication::applicationDirPath()).toString();
+	QString asciiGridSavePath = settings.value("savePathASCIIGrid", ccFileUtils::defaultDocPath()).toString();
 
 	//open file saving dialog
 	QString filter("ASCII file (*.txt)");

--- a/qCC/db_tree/matrixDisplayDlg.cpp
+++ b/qCC/db_tree/matrixDisplayDlg.cpp
@@ -23,6 +23,9 @@
 //qCC_gl
 #include <ccGuiParameters.h>
 
+// qCC_db
+#include "ccFileUtils.h"
+
 //Qt
 #include <QFileDialog>
 #include <QSettings>
@@ -106,7 +109,7 @@ void MatrixDisplayDlg::exportToASCII()
 	//persistent settings
 	QSettings settings;
 	settings.beginGroup(ccPS::LoadFile()); //use the same folder as the load one
-	QString currentPath = settings.value(ccPS::CurrentPath(),QApplication::applicationDirPath()).toString();
+	QString currentPath = settings.value(ccPS::CurrentPath(), ccFileUtils::defaultDocPath()).toString();
 
 	QString outputFilename = QFileDialog::getSaveFileName(this, "Select output file", currentPath, "*.mat.txt");
 	if (outputFilename.isEmpty())

--- a/qCC/main.cpp
+++ b/qCC/main.cpp
@@ -19,6 +19,7 @@
 
 //Qt
 #include <QApplication>
+#include <QDir>
 #include <QSplashScreen>
 #include <QPixmap>
 #include <QMessageBox>
@@ -147,19 +148,19 @@ int main(int argc, char **argv)
 	VLDEnable();
 #endif
 
-#ifdef Q_OS_MAC	
-	// This makes sure that our "working directory" is not within the application bundle
-	QDir  appDir = QCoreApplication::applicationDirPath();
+	QDir  workingDir = QCoreApplication::applicationDirPath();
 	
-	if ( appDir.dirName() == "MacOS" )
+#ifdef Q_OS_MAC	
+	// This makes sure that our "working directory" is not within the application bundle	
+	if ( workingDir.dirName() == "MacOS" )
 	{
-		appDir.cdUp();
-		appDir.cdUp();
-		appDir.cdUp();
-		
-		QDir::setCurrent( appDir.absolutePath() );
+		workingDir.cdUp();
+		workingDir.cdUp();
+		workingDir.cdUp();		
 	}
 #endif
+
+	QDir::setCurrent( workingDir.absolutePath() );
 
 	//store the log message until a valid logging instance is registered
 	ccLog::EnableMessageBackup(true);

--- a/qCC/mainwindow.cpp
+++ b/qCC/mainwindow.cpp
@@ -45,6 +45,7 @@
 #include <cc2DViewportObject.h>
 #include <ccColorScalesManager.h>
 #include <ccFacet.h>
+#include <ccFileUtils.h>
 #include <ccQuadric.h>
 #include <ccSphere.h>
 
@@ -2767,7 +2768,7 @@ void MainWindow::doActionExportDepthBuffer()
 	//persistent settings
 	QSettings settings;
 	settings.beginGroup(ccPS::SaveFile());
-	QString currentPath = settings.value(ccPS::CurrentPath(),QApplication::applicationDirPath()).toString();
+	QString currentPath = settings.value(ccPS::CurrentPath(), ccFileUtils::defaultDocPath()).toString();
 
 	QString filename = QFileDialog::getSaveFileName(this, "Select output file", currentPath, DepthMapFileFilter::GetFileFilter());
 	if (filename.isEmpty())
@@ -8528,7 +8529,7 @@ void MainWindow::doActionComputeBestICPRmsMatrix()
 		//persistent settings
 		QSettings settings;
 		settings.beginGroup(ccPS::SaveFile());
-		QString currentPath = settings.value(ccPS::CurrentPath(),QApplication::applicationDirPath()).toString();
+		QString currentPath = settings.value(ccPS::CurrentPath(), ccFileUtils::defaultDocPath()).toString();
 
 		QString outputFilename = QFileDialog::getSaveFileName(this, "Select output file", currentPath, "*.csv");
 		if (outputFilename.isEmpty())
@@ -8600,7 +8601,7 @@ void MainWindow::doActionExportCloudsInfo()
 	//persistent settings
 	QSettings settings;
 	settings.beginGroup(ccPS::SaveFile());
-	QString currentPath = settings.value(ccPS::CurrentPath(),QApplication::applicationDirPath()).toString();
+	QString currentPath = settings.value(ccPS::CurrentPath(), ccFileUtils::defaultDocPath()).toString();
 
 	QString outputFilename = QFileDialog::getSaveFileName(this, "Select output file", currentPath, "*.csv");
 	if (outputFilename.isEmpty())
@@ -9309,7 +9310,7 @@ void MainWindow::doActionLoadFile()
 	//persistent settings
 	QSettings settings;
 	settings.beginGroup(ccPS::LoadFile());
-	QString currentPath = settings.value(ccPS::CurrentPath(),QApplication::applicationDirPath()).toString();
+	QString currentPath = settings.value(ccPS::CurrentPath(), ccFileUtils::defaultDocPath()).toString();
 	QString currentOpenDlgFilter = settings.value(ccPS::SelectedInputFilter(),BinFilter::GetFileFilter()).toString();
 
 	// Add all available file I/O filters (with import capabilities)
@@ -9568,7 +9569,7 @@ void MainWindow::doActionSaveFile()
 		selectedFilter = settings.value(ccPS::SelectedOutputFilterPoly(), selectedFilter).toString();
 	
 	//default output path (+ filename)
-	QString currentPath = settings.value(ccPS::CurrentPath(),QApplication::applicationDirPath()).toString();
+	QString currentPath = settings.value(ccPS::CurrentPath(), ccFileUtils::defaultDocPath()).toString();
 	QString fullPathName = currentPath;
 	if (selNum == 1)
 	{


### PR DESCRIPTION
Generally there are three paths we are interested in:

1) "next to" the app
2) place to store user data (file dialog defaults)
3) place to find plugins and other internal support files

This commit fixes (1) for macOS so it can find the global shift file (fixes #454) . It does this by setting the current directory on startup and using it to look for things. So on the Mac it get set to "beside the .app", and on Windows & Linux if should remain as it was before.

This commit also changes dialogs to use the user's documents directory as the default for (2) by using QStandardPaths.

(3) wasn't changed by this commit.