### PR TITLE
Cleanup

### DIFF
--- a/libs/qCC_db/ccGenericMesh.cpp
+++ b/libs/qCC_db/ccGenericMesh.cpp
@@ -113,23 +113,23 @@ void ccGenericMesh::EnableGLStippleMask(const QOpenGLContext* context, bool stat
 }
 
 //Vertex buffer
-PointCoordinateType s_xyzBuffer[MAX_NUMBER_OF_ELEMENTS_PER_CHUNK*3*3];
 PointCoordinateType* ccGenericMesh::GetVertexBuffer()
 {
+	static PointCoordinateType s_xyzBuffer[MAX_NUMBER_OF_ELEMENTS_PER_CHUNK*3*3];
 	return s_xyzBuffer;
 }
 
 //Normals buffer
-PointCoordinateType s_normBuffer[MAX_NUMBER_OF_ELEMENTS_PER_CHUNK*3*3];
 PointCoordinateType* ccGenericMesh::GetNormalsBuffer()
 {
+	static PointCoordinateType s_normBuffer[MAX_NUMBER_OF_ELEMENTS_PER_CHUNK*3*3];
 	return s_normBuffer;
 }
 
 //Colors buffer
-ColorCompType s_rgbBuffer[MAX_NUMBER_OF_ELEMENTS_PER_CHUNK*3*3];
 ColorCompType* ccGenericMesh::GetColorsBuffer()
 {
+	static ColorCompType s_rgbBuffer[MAX_NUMBER_OF_ELEMENTS_PER_CHUNK*3*3];
 	return s_rgbBuffer;
 }
 

--- a/libs/qCC_db/ccPointCloud.cpp
+++ b/libs/qCC_db/ccPointCloud.cpp
@@ -2578,7 +2578,7 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 					unsigned steps = m_currentDisplayedScalarField->getColorRampSteps();
 					assert(steps != 0);
 
-					if (steps > CC_MAX_SHADER_COLOR_RAMP_SIZE || maxComponents < (GLint)steps)
+					if (steps > CC_MAX_SHADER_COLOR_RAMP_SIZE || maxComponents < static_cast<GLint>(steps))
 					{
 						ccLog::WarningDebug("Color ramp steps exceed shader limits!");
 						colorRampShader = 0;
@@ -3162,7 +3162,7 @@ void ccPointCloud::deleteScalarField(int index)
 
 	//current SF should still be up-to-date!
 	if (m_currentInScalarFieldIndex < 0 && getNumberOfScalarFields() > 0)
-		setCurrentInScalarField((int)getNumberOfScalarFields()-1);
+		setCurrentInScalarField(static_cast<int>(getNumberOfScalarFields()-1));
 
 	setCurrentDisplayedScalarField(m_currentInScalarFieldIndex);
 	showSF(m_currentInScalarFieldIndex >= 0);

--- a/libs/qCC_db/ccPointCloud.cpp
+++ b/libs/qCC_db/ccPointCloud.cpp
@@ -431,11 +431,12 @@ void ccPointCloud::clear()
 
 void ccPointCloud::unalloactePoints()
 {
+	clearLOD();	// we have to clear the LOD structure before clearing the colors / SFs, so we can't leave it to notifyGeometryUpdate()
 	showSFColorsScale(false); //SFs will be destroyed
 	ChunkedPointCloud::clear();
 	ccGenericPointCloud::clear();
 
-	notifyGeometryUpdate(); //calls releaseVBOs() & clearLOD()
+	notifyGeometryUpdate(); //calls releaseVBOs()
 }
 
 void ccPointCloud::notifyGeometryUpdate()

--- a/libs/qCC_db/ccPointCloud.cpp
+++ b/libs/qCC_db/ccPointCloud.cpp
@@ -431,12 +431,11 @@ void ccPointCloud::clear()
 
 void ccPointCloud::unalloactePoints()
 {
-	clearLOD();
 	showSFColorsScale(false); //SFs will be destroyed
 	ChunkedPointCloud::clear();
 	ccGenericPointCloud::clear();
 
-	notifyGeometryUpdate(); //calls releaseVBOs()
+	notifyGeometryUpdate(); //calls releaseVBOs() & clearLOD()
 }
 
 void ccPointCloud::notifyGeometryUpdate()

--- a/libs/qCC_db/ccPointCloud.cpp
+++ b/libs/qCC_db/ccPointCloud.cpp
@@ -2258,16 +2258,16 @@ struct DisplayDesc : LODLevelDesc
 	DisplayDesc()
 		: LODLevelDesc()
 		, endIndex(0)
-		, indexMap(0)
 		, decimStep(1)
+		, indexMap(nullptr)
 	{}
 
 	//! Constructor from a start index and a count value
 	DisplayDesc(unsigned startIndex, unsigned count)
 		: LODLevelDesc(startIndex, count)
 		, endIndex(startIndex+count)
-		, indexMap(0)
 		, decimStep(1)
+		, indexMap(nullptr)
 	{}
 
 	//! Set operator
@@ -2281,12 +2281,12 @@ struct DisplayDesc : LODLevelDesc
 	
 	//! Last index (excluded)
 	unsigned endIndex;
+	
+	//! Decimation step (for non-octree based LoD)
+	unsigned decimStep;
 
 	//! Map of indexes (to invert the natural order)
 	LODIndexSet* indexMap;
-
-	//! Decimation step (for non-octree based LoD)
-	unsigned decimStep;
 };
 
 struct LODBasedRenderingParams

--- a/libs/qCC_db/ccPointCloud.h
+++ b/libs/qCC_db/ccPointCloud.h
@@ -70,7 +70,7 @@ public:
 		added to this cloud, at least partially).
 		\param name cloud name (optional)
 	**/
-	ccPointCloud(QString name = QString()) throw();
+	ccPointCloud(QString name = QString()) noexcept;
 
 	//! Default destructor
 	virtual ~ccPointCloud();
@@ -728,11 +728,11 @@ protected: // VBO
 		vboSet()
 			: hasColors(false)
 			, colorIsSF(false)
-			, sourceSF(0)
+			, sourceSF(nullptr)
 			, hasNormals(false)
 			, totalMemSizeBytes(0)
-			, state(NEW)
 			, updateFlags(0)
+			, state(NEW)
 		{}
 
 		std::vector<VBO*> vbos;


### PR DESCRIPTION
A series of small changes:

- avoids extra call to `ccPointCloud::clearLOD()` in `ccPointCloud::unalloactePoints()`
- reorder member variables to avoid padding in `struct DisplayDesc`
- converts a couple of old-style casts to `static_cast`
- convert dynamic exception specification (deprecated) to `noexcept`
- prefer `nullptr` to "0" for pointer initialization
- reorder initialization list to match declarations