### PR TITLE
Cleanups

### DIFF
--- a/libs/qCC_db/ccPointCloud.cpp
+++ b/libs/qCC_db/ccPointCloud.cpp
@@ -2290,17 +2290,6 @@ struct DisplayDesc : LODLevelDesc
 	LODIndexSet* indexMap;
 };
 
-struct LODBasedRenderingParams
-{
-	ccScalarField* activeSF;
-	const ccNormalVectors* compressedNormals;
-	PointCoordinateType* _points;
-	PointCoordinateType* _normals;
-	ColorCompType* _rgb;
-	GLsizei bufferCount;
-	QOpenGLFunctions_2_1* glFunc;
-};
-
 void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 {
 	if (!m_points->isAllocated())

--- a/libs/qCC_db/ccPointCloudLOD.cpp
+++ b/libs/qCC_db/ccPointCloudLOD.cpp
@@ -558,6 +558,7 @@ public:
 		: m_lod(lod)
 		, m_frustum(frustum)
 		, m_maxLevel(maxLevel)
+		, m_hasClipPlanes(false)
 	{}
 
 	void setClipPlanes(const ccClipPlaneSet& clipPlanes)

--- a/libs/qCC_db/ccPointCloudLOD.h
+++ b/libs/qCC_db/ccPointCloudLOD.h
@@ -268,7 +268,7 @@ public:
 	typedef std::function<void(const ccPointCloudLOD::Node&)> RenderFunc;
 
 	PointCloudLODRenderer(	ccPointCloudLOD& lod,
-							RenderFunc func,
+							RenderFunc &func,
 							const Frustum& frustum,
 							unsigned char maxLevel)
 		: m_func(func)

--- a/libs/qCC_io/PDMS/PdmsParser.cpp
+++ b/libs/qCC_io/PDMS/PdmsParser.cpp
@@ -272,12 +272,12 @@ void PdmsLexer::pushIntoDictionnary(const char *str, Token token, int minSize)
 		dictionnary[std::string(str).substr(0, minSize)] = token;
 }
 
-PdmsFileSession::PdmsFileSession(std::string filename)
-	: m_filename(filename)
-	, m_currentLine(-1)
-	, m_eol(false)
-	, m_eof(false)
-	, m_file(0)
+PdmsFileSession::PdmsFileSession(const std::string &filename)
+    : m_filename(filename)
+    , m_currentLine(-1)
+    , m_eol(false)
+    , m_eof(false)
+    , m_file(0)
 {}
 
 bool PdmsFileSession::initializeSession()

--- a/libs/qCC_io/PDMS/PdmsParser.h
+++ b/libs/qCC_io/PDMS/PdmsParser.h
@@ -81,7 +81,7 @@ protected:
 	FILE* m_file;
 
 public:
-	PdmsFileSession(std::string filename);
+	PdmsFileSession(const std::string &filename);
 	virtual ~PdmsFileSession() {closeSession();}
 	virtual bool initializeSession();
 	virtual void closeSession(bool destroyLoadedObject=false);


### PR DESCRIPTION
- removes unused struct
- pass parameters by ref
- make sure to initialize all member vars