### PR TITLE
Factor out 3d mouse code from main window

### DIFF
--- a/plugins/ccMainAppInterface.h
+++ b/plugins/ccMainAppInterface.h
@@ -33,7 +33,7 @@ class ccOverlayDialog;
 class ccMainAppInterface
 {
 public:
-	
+
 	//! Returns main window
 	virtual QMainWindow* getMainWindow() = 0;
 
@@ -72,10 +72,10 @@ public:
 		\param autoRedraw whether to redraw the 3D view automatically or not (warning: if 'updateZoom' is true, the 3D view will always be redrawn)
 	**/
 	virtual void addToDB(	ccHObject* obj,
-							bool updateZoom = false,
-							bool autoExpandDBTree = true,
-							bool checkDimensions = false,
-							bool autoRedraw = true) = 0;
+		                    bool updateZoom = false,
+		                    bool autoExpandDBTree = true,
+		                    bool checkDimensions = false,
+		                    bool autoRedraw = true) = 0;
 
 	//! Removes an entity from main db tree
 	/** Object is automatically detached from its parent.
@@ -148,18 +148,21 @@ public:
 
 	//! Spawns an histogram dialog
 	virtual void spawnHistogramDialog(	const std::vector<unsigned>& histoValues,
-										double minVal,
-										double maxVal,
-										QString title,
-										QString xAxisLabel) = 0;
+	                                    double minVal,
+	                                    double maxVal,
+	                                    QString title,
+	                                    QString xAxisLabel) = 0;
 
-	//other usefull methods
+	//other useful methods
 	virtual void setFrontView() = 0;
 	virtual void setBottomView() = 0;
 	virtual void setTopView() = 0;
 	virtual void setBackView() = 0;
 	virtual void setLeftView() = 0;
 	virtual void setRightView() = 0;
+	virtual void setIsoView1() = 0;
+	virtual void setIsoView2() = 0;
+
 	virtual void toggleActiveWindowCenteredPerspective() = 0;
 	virtual void toggleActiveWindowCustomLight() = 0;
 	virtual void toggleActiveWindowSunLight() = 0;

--- a/qCC/devices/3dConnexion/Mouse3DInput.cpp
+++ b/qCC/devices/3dConnexion/Mouse3DInput.cpp
@@ -69,9 +69,9 @@ public:
 	}
 };
 
-Mouse3DInput::Mouse3DInput(QWidget* widget)
-	: QObject(widget)
-	, m_siHandle(SI_NO_HANDLE)
+Mouse3DInput::Mouse3DInput(QObject* parent)
+    : QObject(parent)
+    , m_siHandle(SI_NO_HANDLE)
 {
 	//register current instance
 	assert(s_mouseInputInstance == 0);
@@ -109,7 +109,7 @@ bool Mouse3DInput::connect(QWidget* mainWidget, QString appName)
 	SiOpenWinInit(&oData, (HWND)mainWidget->winId() );
 	//3DxWare device handle
 	m_siHandle = SiOpen(qPrintable(appName), SI_ANY_DEVICE, SI_NO_MASK, SI_EVENT, &oData);
-	
+
 	if (m_siHandle == SI_NO_HANDLE)
 	{
 		/* Get and display initialization error */
@@ -172,11 +172,11 @@ bool Mouse3DInput::onSiEvent(void* siGetEventData)
 			const SiSpwData& eventData = siEvent.u.spwData;
 
 			if (	eventData.mData[SI_TX] != 0
-				||	eventData.mData[SI_TY] != 0
-				||	eventData.mData[SI_TZ] != 0
-				||	eventData.mData[SI_RX] != 0
-				||	eventData.mData[SI_RY] != 0
-				||	eventData.mData[SI_RZ] != 0 )
+			    ||	eventData.mData[SI_TY] != 0
+			    ||	eventData.mData[SI_TZ] != 0
+			    ||	eventData.mData[SI_RX] != 0
+			    ||	eventData.mData[SI_RY] != 0
+			    ||	eventData.mData[SI_RZ] != 0 )
 			{
 				std::vector<float> axes(6);
 				double ds = eventData.period * c_3dmouseAngularVelocity; //period is in ms
@@ -273,7 +273,7 @@ void Mouse3DInput::Apply(const std::vector<float>& motionData, ccGLWindow* win)
 	std::vector<float> vec = motionData;
 
 	//view parameters
-	bool objectMode = true; 
+	bool objectMode = true;
 	bool perspectiveView = win->getPerspectiveState(objectMode); //note: viewer based perspective IS 'camera mode'
 	bool bubbleViewMode = win->bubbleViewModeEnabled();
 
@@ -295,8 +295,8 @@ void Mouse3DInput::Apply(const std::vector<float>& motionData, ccGLWindow* win)
 
 		//Zoom & Panning: camera moves right/left + up/down + backward/forward (only for perspective mode)
 		if (	fabs(X) > ZERO_TOLERANCE
-			||	fabs(Y) > ZERO_TOLERANCE
-			||	fabs(Z) > ZERO_TOLERANCE )
+		    ||	fabs(Y) > ZERO_TOLERANCE
+		    ||	fabs(Z) > ZERO_TOLERANCE )
 		{
 			const ccViewportParameters& viewParams = win->getViewportParameters();
 
@@ -323,8 +323,8 @@ void Mouse3DInput::Apply(const std::vector<float>& motionData, ccGLWindow* win)
 
 	//rotation
 	if (	fabs(vec[3]) > ZERO_TOLERANCE
-		||	fabs(vec[4]) > ZERO_TOLERANCE
-		||	fabs(vec[5]) > ZERO_TOLERANCE)
+	    ||	fabs(vec[4]) > ZERO_TOLERANCE
+	    ||	fabs(vec[5]) > ZERO_TOLERANCE)
 	{
 		//ccLog::Print(QString("Mouse rotation: (%1,%2,%3)").arg(vec[3]).arg(vec[4]).arg(vec[5]));
 

--- a/qCC/devices/3dConnexion/Mouse3DInput.h
+++ b/qCC/devices/3dConnexion/Mouse3DInput.h
@@ -25,7 +25,7 @@
 #include <ccGLMatrix.h>
 
 //Qt
-#include <QWidget>
+#include <QObject>
 
 //system
 #include <vector>
@@ -40,7 +40,7 @@ class Mouse3DInput : public QObject
 public:
 
 	//! Default constructor
-	explicit Mouse3DInput(QWidget* widget);
+	explicit Mouse3DInput(QObject* parent);
 	//! Destructor
 	virtual ~Mouse3DInput();
 

--- a/qCC/devices/3dConnexion/cc3DMouseManager.cpp
+++ b/qCC/devices/3dConnexion/cc3DMouseManager.cpp
@@ -1,0 +1,229 @@
+//##########################################################################
+//#                                                                        #
+//#                              CLOUDCOMPARE                              #
+//#                                                                        #
+//#  This program is free software; you can redistribute it and/or modify  #
+//#  it under the terms of the GNU General Public License as published by  #
+//#  the Free Software Foundation; version 2 or later of the License.      #
+//#                                                                        #
+//#  This program is distributed in the hope that it will be useful,       #
+//#  but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+//#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the          #
+//#  GNU General Public License for more details.                          #
+//#                                                                        #
+//#          COPYRIGHT: CloudCompare project                               #
+//#                                                                        #
+//##########################################################################
+
+#include <QAction>
+#include <QMainWindow>
+#include <QMenu>
+
+#include "cc3DMouseManager.h"
+#include "ccGLWindow.h"
+
+#include "ccMainAppInterface.h"
+
+#include "devices/3dConnexion/Mouse3DInput.h"
+
+
+cc3DMouseManager::cc3DMouseManager( ccMainAppInterface *appInterface, QObject *parent ) :
+	QObject( parent ),
+	mAppInterface( appInterface ),
+	m3dMouseInput( nullptr )
+{
+	setupMenu();
+	
+	enable3DMouse(true, true);	
+}
+
+cc3DMouseManager::~cc3DMouseManager()
+{
+	release3DMouse();	
+}
+
+void cc3DMouseManager::enable3DMouse(bool state, bool silent)
+{
+	if (m3dMouseInput)
+	{
+		release3DMouse();
+	}
+	
+	if (state)
+	{
+		m3dMouseInput = new Mouse3DInput(this);
+		if (m3dMouseInput->connect(mAppInterface->getMainWindow(),"CloudCompare"))
+		{
+			connect(m3dMouseInput, &Mouse3DInput::sigMove3d, this, &cc3DMouseManager::on3DMouseMove);
+			connect(m3dMouseInput, &Mouse3DInput::sigReleased, this, &cc3DMouseManager::on3DMouseReleased);
+			connect(m3dMouseInput, &Mouse3DInput::sigOn3dmouseKeyDown, this, &cc3DMouseManager::on3DMouseKeyDown);
+			connect(m3dMouseInput, &Mouse3DInput::sigOn3dmouseKeyUp, this, &cc3DMouseManager::on3DMouseKeyUp);
+		}
+		else
+		{
+			delete m3dMouseInput;
+			m3dMouseInput = nullptr;
+			
+			if (!silent)
+			{
+				ccLog::Error("[3D Mouse] No device found"); //warning message has already been issued by Mouse3DInput::connect
+			}
+			state = false;
+		}
+	}
+	else
+	{
+		ccLog::Warning("[3D Mouse] Device has been disabled");
+	}
+	
+	mActionEnable3DMouse->blockSignals(true);
+	mActionEnable3DMouse->setChecked(state);
+	mActionEnable3DMouse->blockSignals(false);
+}
+
+void cc3DMouseManager::release3DMouse()
+{
+	if (m3dMouseInput == nullptr)
+		return;
+	
+	m3dMouseInput->disconnectDriver(); //disconnect from the driver
+	m3dMouseInput->disconnect(this); //disconnect from Qt ;)
+	
+	delete m3dMouseInput;
+	m3dMouseInput = nullptr;
+}
+
+void cc3DMouseManager::on3DMouseKeyUp(int)
+{
+	//nothing right now
+}
+
+// ANY CHANGE/BUG FIX SHOULD BE REFLECTED TO THE EQUIVALENT METHODS IN QCC "MainWindow.cpp" FILE!
+void cc3DMouseManager::on3DMouseKeyDown(int key)
+{
+	switch(key)
+	{
+		case Mouse3DInput::V3DK_MENU:
+			//should be handled by the driver now!
+			break;
+		case Mouse3DInput::V3DK_FIT:
+		{
+			if (mAppInterface->getSelectedEntities().empty())
+			{
+				ccGLWindow* win = mAppInterface->getActiveGLWindow();
+				if (win)
+					win->zoomGlobal();
+			}
+			else
+			{
+				mAppInterface->zoomOnSelectedEntities();
+			}
+		}
+			break;
+		case Mouse3DInput::V3DK_TOP:
+			mAppInterface->setTopView();
+			break;
+		case Mouse3DInput::V3DK_LEFT:
+			mAppInterface->setLeftView();
+			break;
+		case Mouse3DInput::V3DK_RIGHT:
+			mAppInterface->setRightView();
+			break;
+		case Mouse3DInput::V3DK_FRONT:
+			mAppInterface->setFrontView();
+			break;
+		case Mouse3DInput::V3DK_BOTTOM:
+			mAppInterface->setBottomView();
+			break;
+		case Mouse3DInput::V3DK_BACK:
+			mAppInterface->setBackView();
+			break;
+		case Mouse3DInput::V3DK_ROTATE:
+			//should be handled by the driver now!
+			break;
+		case Mouse3DInput::V3DK_PANZOOM:
+			//should be handled by the driver now!
+			break;
+		case Mouse3DInput::V3DK_ISO1:
+			mAppInterface->setIsoView1();
+			break;
+		case Mouse3DInput::V3DK_ISO2:
+			mAppInterface->setIsoView2();
+			break;
+		case Mouse3DInput::V3DK_PLUS:
+			//should be handled by the driver now!
+			break;
+		case Mouse3DInput::V3DK_MINUS:
+			//should be handled by the driver now!
+			break;
+		case Mouse3DInput::V3DK_DOMINANT:
+			//should be handled by the driver now!
+			break;
+		case Mouse3DInput::V3DK_CW:
+		case Mouse3DInput::V3DK_CCW:
+		{
+			ccGLWindow* activeWin = mAppInterface->getActiveGLWindow();
+			if (activeWin != nullptr)
+			{
+				CCVector3d axis(0,0,-1);
+				CCVector3d trans(0,0,0);
+				ccGLMatrixd mat;
+				double angle = M_PI/2;
+				if (key == Mouse3DInput::V3DK_CCW)
+				{
+					angle = -angle;
+				}
+				mat.initFromParameters(angle,axis,trans);
+				activeWin->rotateBaseViewMat(mat);
+				activeWin->redraw();
+			}
+		}
+			break;
+		case Mouse3DInput::V3DK_ESC:
+		case Mouse3DInput::V3DK_ALT:
+		case Mouse3DInput::V3DK_SHIFT:
+		case Mouse3DInput::V3DK_CTRL:
+		default:
+			ccLog::Warning("[3D mouse] This button is not handled (yet)");
+			//TODO
+			break;
+	}
+}
+
+void cc3DMouseManager::on3DMouseMove(std::vector<float>& vec)
+{
+	ccGLWindow* win = mAppInterface->getActiveGLWindow();
+	if (win == nullptr)
+		return;
+	
+	Mouse3DInput::Apply(vec, win);
+}
+
+void cc3DMouseManager::on3DMouseReleased()
+{
+	ccGLWindow* win = mAppInterface->getActiveGLWindow();
+	if (win == nullptr)
+		return;
+
+	if (win->getPivotVisibility() == ccGLWindow::PIVOT_SHOW_ON_MOVE)
+	{
+		//we have to hide the pivot symbol!
+		win->showPivotSymbol(false);
+		win->redraw();
+	}
+}
+
+void cc3DMouseManager::setupMenu()
+{
+	mMenu3DMouse = new QMenu( "3D Mouse" );
+	mMenu3DMouse->setIcon( QIcon(":/CC/images/im3DxLogo.png") );
+	
+	mActionEnable3DMouse = new QAction( tr( "Enable" ), this );
+	mActionEnable3DMouse->setCheckable( true );
+	
+	connect( mActionEnable3DMouse, &QAction::toggled, [this](bool state) {
+		enable3DMouse(state, false);
+	});
+	
+	mMenu3DMouse->addAction( mActionEnable3DMouse );
+}

--- a/qCC/devices/3dConnexion/cc3DMouseManager.h
+++ b/qCC/devices/3dConnexion/cc3DMouseManager.h
@@ -1,0 +1,67 @@
+#ifndef CC3DMOUSEMANAGER_H
+#define CC3DMOUSEMANAGER_H
+
+//##########################################################################
+//#                                                                        #
+//#                              CLOUDCOMPARE                              #
+//#                                                                        #
+//#  This program is free software; you can redistribute it and/or modify  #
+//#  it under the terms of the GNU General Public License as published by  #
+//#  the Free Software Foundation; version 2 or later of the License.      #
+//#                                                                        #
+//#  This program is distributed in the hope that it will be useful,       #
+//#  but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+//#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the          #
+//#  GNU General Public License for more details.                          #
+//#                                                                        #
+//#          COPYRIGHT: CloudCompare project                               #
+//#                                                                        #
+//##########################################################################
+
+#include <QObject>
+
+class QAction;
+class QMenu;
+
+class ccMainAppInterface;
+class Mouse3DInput;
+
+
+class cc3DMouseManager : public QObject
+{
+	Q_OBJECT
+	
+public:
+	cc3DMouseManager( ccMainAppInterface *appInterface, QObject *parent );
+	~cc3DMouseManager();
+	
+	//! Gets the menu associated with the 3D mouse
+	QMenu	*menu() { return mMenu3DMouse; }
+	
+	//! Tries to enable (or disable) a 3D mouse device
+	/** \param state whether to enable or disable the device
+	 *	\param silent whether to issue an error message in case of failure
+	**/
+	void enable3DMouse(bool state, bool silent);
+	
+	//! Releases any connected 3D mouse
+	void release3DMouse();
+	
+private:
+	void setupMenu();
+	
+	void on3DMouseKeyUp(int key);
+	void on3DMouseKeyDown(int key);
+	void on3DMouseMove(std::vector<float> &vec);
+	void on3DMouseReleased();
+	
+	
+	ccMainAppInterface	*mAppInterface;
+	
+	Mouse3DInput	*m3dMouseInput;
+	
+	QMenu	*mMenu3DMouse;
+	QAction *mActionEnable3DMouse;
+};
+
+#endif

--- a/qCC/mainwindow.h
+++ b/qCC/mainwindow.h
@@ -62,7 +62,7 @@ class ccPrimitiveFactoryDlg;
 class ccDrawableObject;
 class ccOverlayDialog;
 class QMdiSubWindow;
-class Mouse3DInput;
+class cc3DMouseManager;
 class GamepadInput;
 
 //! Main window
@@ -456,15 +456,6 @@ protected slots:
 	void doActionShowActiveSFPrevious();
 	void doActionShowActiveSFNext();
 
-	//3D mouse
-	void on3DMouseMove(std::vector<float>&);
-	void on3DMouseKeyUp(int);
-	void on3DMouseKeyDown(int);
-	void on3DMouseReleased();
-
-	//! Setups 3D mouse (if any)
-	void setup3DMouse(bool state) { enable3DMouse(state, false); }
-
 	//Gamepad
 	void onGamepadInput();
 	void increasePointSize();
@@ -551,15 +542,6 @@ protected:
 	//! Expands DB tree for selected items
 	void expandDBTreeWithSelection(ccHObject::Container& selection);
 
-	//! Trys to enable (or disable) a 3D mouse device
-	/** \param state whether to enable or disable the device
-		\param silent whether to issue an error message in case of failure
-	**/
-	void enable3DMouse(bool state, bool silent);
-
-	//! Releases any connected 3D mouse
-	void release3DMouse();
-
 	//! Releases any connected gamepad
 	void releaseGamepad();
 
@@ -581,8 +563,8 @@ protected:
 	//! UI frozen state (see freezeUI)
 	bool m_uiFrozen;
 
-	//! 3D mouse handler
-	Mouse3DInput* m_3dMouseInput;
+	//! 3D mouse
+	cc3DMouseManager* m_3DMouseManager;
 
 	//! Gamepad handler
 	GamepadInput* m_gamepadInput;

--- a/qCC/mainwindow.h
+++ b/qCC/mainwindow.h
@@ -236,6 +236,8 @@ protected slots:
 	virtual void setBackView() override;
 	virtual void setLeftView() override;
 	virtual void setRightView() override;
+	virtual void setIsoView1() override;
+	virtual void setIsoView2() override;
 	virtual void toggleActiveWindowStereoVision(bool);
 	virtual void toggleActiveWindowCenteredPerspective() override;
 	virtual void toggleActiveWindowCustomLight() override;
@@ -243,8 +245,6 @@ protected slots:
 	virtual void toggleActiveWindowViewerBasedPerspective() override;
 	virtual void zoomOnSelectedEntities() override;
 
-	void setIsoView1();
-	void setIsoView2();
 	void toggleRotationAboutVertAxis();
 	void doActionEnableBubbleViewMode();
 	void setGlobalZoom();

--- a/qCC/ui_templates/mainWindow.ui
+++ b/qCC/ui_templates/mainWindow.ui
@@ -52,16 +52,6 @@
     <property name="title">
      <string>&amp;File</string>
     </property>
-    <widget class="QMenu" name="menu3DMouse">
-     <property name="title">
-      <string>3D mouse</string>
-     </property>
-     <property name="icon">
-      <iconset resource="../icones.qrc">
-       <normaloff>:/CC/images/im3DxLogo.png</normaloff>:/CC/images/im3DxLogo.png</iconset>
-     </property>
-     <addaction name="actionEnable3DMouse"/>
-    </widget>
     <widget class="QMenu" name="menuGamepad">
      <property name="title">
       <string>Gamepad</string>
@@ -78,7 +68,6 @@
     <addaction name="separator"/>
     <addaction name="actionPrimitiveFactory"/>
     <addaction name="separator"/>
-    <addaction name="menu3DMouse"/>
     <addaction name="menuGamepad"/>
     <addaction name="separator"/>
     <addaction name="actionCloseAll"/>
@@ -2255,14 +2244,6 @@
    </property>
    <property name="shortcutContext">
     <enum>Qt::ApplicationShortcut</enum>
-   </property>
-  </action>
-  <action name="actionEnable3DMouse">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Enable</string>
    </property>
   </action>
   <action name="actionSetOrthoView">


### PR DESCRIPTION
Move the 3D mouse code from MainWindow into a new class.  This provides a more obvious interface between the main window and the 3d mouse code which cleans up MainWindow a bit.

Obviously I don't have a 3D mouse to test this, so...